### PR TITLE
Fixed custom example; needed updated 'src' links

### DIFF
--- a/example/marker-clustering-custom.html
+++ b/example/marker-clustering-custom.html
@@ -11,10 +11,10 @@
 
 
 	<link rel="stylesheet" href="../dist/MarkerCluster.css" />
-	<script src="../src/MarkerClusterGroup.js"></script>
-	<script src="../src/MarkerCluster.js"></script>
-	<script src="../src/MarkerCluster.QuickHull.js"></script>
-	
+	<link rel="stylesheet" href="../dist/MarkerCluster.Default.css" />
+	<!--[if lte IE 8]><link rel="stylesheet" href="../dist/MarkerCluster.Default.ie.css" /><![endif]-->
+	<script src="../dist/leaflet.markercluster-src.js"></script>
+
 	<style>
 		.mycluster {
 			width: 40px;


### PR DESCRIPTION
The custom example found [here](http://danzel.github.com/Leaflet.markercluster/example/marker-clustering-custom.html) is throwing a TypeError, but switching in the 'src' links found in the [everything example](http://danzel.github.com/Leaflet.markercluster/example/marker-clustering-everything.html) made it happy. Should be good to go now.
