### PR TITLE
Fixes #211 - Remove and Re-Add MCG adds the wrong clusters

### DIFF
--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -414,6 +414,10 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 
 		this._bindEvents();
 
+		// if this is a re-add, check to see if the map zoom changed while we were gone
+		if (this._zoom && this._zoom != this._map.getZoom()) {
+			this._mergeSplitClusters();
+		}
 
 		//Actually add our markers to the map:
 


### PR DESCRIPTION
Add code to onAdd to see if this a re-add and if the zoom level changed. If so, call _mergeSplitClusters().
