### PR TITLE
Add a mapCenterOffset option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Other options
 * **singleMarkerMode**: If set to true, overrides the icon for all added markers to make them appear as a 1 size cluster
 * **spiderfyDistanceMultiplier**: Increase from 1 to increase the distance away from the center that spiderfied markers are placed. Use if you are using big marker icons (Default:1)
 * **iconCreateFunction**: Function used to create the cluster icon [See default as example](https://github.com/Leaflet/Leaflet.markercluster/blob/15ed12654acdc54a4521789c498e4603fe4bf781/src/MarkerClusterGroup.js#L542).
+* **mapCenterOffset**: An object containing `paddingTopLeft` and/or `paddingTopRight` `L.Point` values to offset the center zoom of the map. Similar to `fitBounds` in Leaflet.
 
 ## Events
 If you register for click, mouseover, etc events just related to Markers in the cluster.

--- a/example/marker-clustering-realworld.offset.html
+++ b/example/marker-clustering-realworld.offset.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet debug page</title>
+
+	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7/leaflet.css" />
+	<script src="http://cdn.leafletjs.com/leaflet-0.7/leaflet.js"></script>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link rel="stylesheet" href="screen.css" />
+
+	<link rel="stylesheet" href="../dist/MarkerCluster.css" />
+	<link rel="stylesheet" href="../dist/MarkerCluster.Default.css" />
+	<script src="../dist/leaflet.markercluster-src.js"></script>
+	<script src="realworld.388.js"></script>
+
+</head>
+<body>
+
+	<div id="sidebar"></div>
+	<div id="map"></div>
+	<span>Mouse over a cluster to see the bounds of its children and click a cluster to zoom to those bounds</span>
+	<script type="text/javascript">
+
+		var cloudmadeUrl = 'http://{s}.tile.cloudmade.com/BC9A493B41014CAABB98F0471D759707/997/256/{z}/{x}/{y}.png',
+			cloudmadeAttribution = 'Map data &copy; 2011 OpenStreetMap contributors, Imagery &copy; 2011 CloudMade, Points &copy 2012 LINZ',
+			cloudmade = L.tileLayer(cloudmadeUrl, {maxZoom: 17, attribution: cloudmadeAttribution}),
+			latlng = L.latLng(-37.82, 175.21);
+
+		var map = L.map('map', {center: latlng, zoom: 13, layers: [cloudmade]});
+
+		var markers = L.markerClusterGroup({
+			mapCenterOffset: {
+				paddingTopLeft: L.point(200, 0)
+			}
+		});
+		
+		for (var i = 0; i < addressPoints.length; i++) {
+			var a = addressPoints[i];
+			var title = a[2];
+			var marker = L.marker(new L.LatLng(a[0], a[1]), { title: title });
+			marker.bindPopup(title);
+			markers.addLayer(marker);
+		}
+
+		map.addLayer(markers);
+
+	</script>
+</body>
+</html>

--- a/example/screen.css
+++ b/example/screen.css
@@ -20,6 +20,16 @@
     padding: 2px;
 }
 
+#sidebar {
+    background-color: rgba(0, 0, 0, 0.3);
+    position: fixed;
+    left: 8px;
+    height: 602px;
+    width: 200px;
+    top: 8px;
+    z-index: 5;
+}
+
 #progress-bar {
     width: 0;
     height: 100%;

--- a/src/MarkerCluster.js
+++ b/src/MarkerCluster.js
@@ -61,12 +61,30 @@ L.MarkerCluster = L.Marker.extend({
 			childClusters = newClusters;
 		}
 
+		var offset = this._group.options.mapCenterOffset;
+		var tl = offset.paddingTopLeft || 0;
+		var br = offset.paddingBottomRight || 0;
+
 		if (boundsZoom > zoom) {
-			this._group._map.setView(this._latlng, zoom);
+			if (tl || br) {
+				this._group._map.fitBounds(this._bounds, {
+					paddingTopLeft: tl,
+					paddingBottomRight: br
+				});
+			} else {
+				this._group._map.setView(this._latlng, zoom);
+			}
 		} else if (boundsZoom <= mapZoom) { //If fitBounds wouldn't zoom us down, zoom us down instead
 			this._group._map.setView(this._latlng, mapZoom + 1);
 		} else {
-			this._group._map.fitBounds(this._bounds);
+			if (tl || br) {
+				this._group._map.fitBounds(this._bounds, {
+					paddingTopLeft: tl,
+					paddingBottomRight: br
+				});
+			} else {
+				this._group._map.fitBounds(this._bounds);
+			}
 		}
 	},
 
@@ -122,7 +140,7 @@ L.MarkerCluster = L.Marker.extend({
 	//Expand our bounds and tell our parent to
 	_expandBounds: function (marker) {
 		var addedCount,
-		    addedLatLng = marker._wLatLng || marker._latlng;
+			addedLatLng = marker._wLatLng || marker._latlng;
 
 		if (marker instanceof L.MarkerCluster) {
 			this._bounds.extend(marker._bounds);
@@ -313,7 +331,7 @@ L.MarkerCluster = L.Marker.extend({
 	// runAtBottomLevel: function that takes an L.MarkerCluster as an argument that should be applied at only the bottom level
 	_recursively: function (boundsToApplyTo, zoomLevelToStart, zoomLevelToStop, runAtEveryLevel, runAtBottomLevel) {
 		var childClusters = this._childClusters,
-		    zoom = this._zoom,
+			zoom = this._zoom,
 			i, c;
 
 		if (zoomLevelToStart > zoom) { //Still going down to required depth, just recurse to child clusters

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -12,6 +12,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		showCoverageOnHover: true,
 		zoomToBoundsOnClick: true,
 		singleMarkerMode: false,
+		mapCenterOffset: false,
 
 		disableClusteringAtZoom: null,
 


### PR DESCRIPTION
I ended up patching the library to do something like this for Pinterest's implementation (since we have a semi-transparent sidebar that overlaps the map and want the map to center in the *actionable* area, not necessarily the center of the entire map) and wanted to see what your thoughts were on bringing it upstream.

This adds the `mapCenterOffset` option which (false by default) can be an object that contains a `paddingTopLeft` L.point and a `paddingBottomRight` L.point (if only one is supplied, it the other will be `0`). If that option is passed in to the MarkerClusterGroup, when you zoom in on a cluster, it'll offset the zoom to that delta (similar to how Leaflet's [fitbounds](http://leafletjs.com/reference.html#map-fitboundsoptions) options are).

Any thoughts?

(p.s. not sure why the whitespace changes [here](https://github.com/Leaflet/Leaflet.markercluster/pull/322/files#diff-98596be332a339d412518493fe17dd50R1231) and [here](https://github.com/Leaflet/Leaflet.markercluster/pull/322/files#diff-98596be332a339d412518493fe17dd50R1422) are happening but they'd be ironed out before merging.)