### PR TITLE
Issue #330. Gets the parent of a marker in general, visible or not. Changed README to include it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ var visibleOne = markerClusterGroup.getVisibleParent(myMarker);
 console.log(visibleOne.getLatLng());
 ```
 
+### Getting the  parent of a marker (visible or not)
+If you have a marker in your MarkerClusterGroup and you want to get the parent of it (Either itself or a cluster it is contained in).
+```
+var parent  = markerClusterGroup.getParent(myMarker);
+console.log(parent.getLatLng());
+```
+
 ### Adding and removing Markers
 addLayer, removeLayer and clearLayers are supported and they should work for most uses.
 

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -512,12 +512,14 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 	},
 
 	getParent: function (marker) {
-                 var vMarker = marker;
-                 if (vMarker && marker.__parent && marker.__parent._zoom < this._map.getZoom()) return marker;
-                 while (vMarker && vMarker.__parent && (vMarker._zoom > this._map.getZoom() || !vMarker._zoom)) {
-                         vMarker = vMarker.__parent;
-                 };
-                 return vMarker;
+                var vMarker = marker;
+                if (vMarker && marker.__parent && marker.__parent._zoom < this._map.getZoom()) {
+                        return marker;
+                }
+                while (vMarker && vMarker.__parent && (vMarker._zoom > this._map.getZoom() || !vMarker._zoom)) {
+                        vMarker = vMarker.__parent;
+                }
+                return vMarker;
         },
 
 	//Remove the given object from the given array

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -513,8 +513,8 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 
 	getParent: function (marker) {
                  var vMarker = marker;
-                 if (vMarker && marker.__parent && marker.__parent._zoom < map.getZoom()) return marker;
-                 while (vMarker && vMarker.__parent && (vMarker._zoom > map.getZoom() || !vMarker._zoom)) {
+                 if (vMarker && marker.__parent && marker.__parent._zoom < this._map.getZoom()) return marker;
+                 while (vMarker && vMarker.__parent && (vMarker._zoom > this._map.getZoom() || !vMarker._zoom)) {
                          vMarker = vMarker.__parent;
                  };
                  return vMarker;

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -511,6 +511,15 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		return vMarker || null;
 	},
 
+	getParent: function (marker) {
+                 var vMarker = marker;
+                 if (marker.__parent && marker.__parent._zoom < map.getZoom()) return marker;
+                 while (vMarker.__parent && (vMarker._zoom > map.getZoom() || !vMarker._zoom)) {
+                         vMarker = vMarker.__parent;
+                 };
+                 return vMarker;
+        },
+
 	//Remove the given object from the given array
 	_arraySplice: function (anArray, obj) {
 		for (var i = anArray.length - 1; i >= 0; i--) {

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -513,8 +513,8 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 
 	getParent: function (marker) {
                  var vMarker = marker;
-                 if (marker.__parent && marker.__parent._zoom < map.getZoom()) return marker;
-                 while (vMarker.__parent && (vMarker._zoom > map.getZoom() || !vMarker._zoom)) {
+                 if (vMarker && marker.__parent && marker.__parent._zoom < map.getZoom()) return marker;
+                 while (vMarker && vMarker.__parent && (vMarker._zoom > map.getZoom() || !vMarker._zoom)) {
                          vMarker = vMarker.__parent;
                  };
                  return vMarker;

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -512,15 +512,15 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 	},
 
 	getParent: function (marker) {
-                var vMarker = marker;
-                if (vMarker && marker.__parent && marker.__parent._zoom < this._map.getZoom()) {
-                        return marker;
-                }
-                while (vMarker && vMarker.__parent && (vMarker._zoom > this._map.getZoom() || !vMarker._zoom)) {
-                        vMarker = vMarker.__parent;
-                }
-                return vMarker;
-        },
+		var vMarker = marker;
+		if (vMarker && marker.__parent && marker.__parent._zoom < this._map.getZoom()) {
+			return marker;
+		}
+		while (vMarker && vMarker.__parent && (vMarker._zoom > this._map.getZoom() || !vMarker._zoom)) {
+			vMarker = vMarker.__parent;
+		}
+        	return vMarker;
+	},
 
 	//Remove the given object from the given array
 	_arraySplice: function (anArray, obj) {


### PR DESCRIPTION
As my issue mentioned, it would be nice to get the parent of a marker without the requirement of it being visible. This is what I implemented.

If you have a marker in your MarkerClusterGroup and you want to get the parent of it (Either itself or a cluster it is contained in).
```
var parent  = markerClusterGroup.getParent(myMarker);
console.log(parent.getLatLng());
`````