### PR TITLE
Provide more detailed context information on the spiderfied event

### DIFF
--- a/spec/suites/spiderfySpec.js
+++ b/spec/suites/spiderfySpec.js
@@ -89,4 +89,56 @@
 			expect(group._spiderfied).to.be(null);
 		});
 	});
+
+	describe('spiderfied event listener', function () {
+		it('Spiderfies 2 Markers', function (done) {
+
+			var group = new L.MarkerClusterGroup();
+			var marker = new L.Marker([1.5, 1.5]);
+			var marker2 = new L.Marker([1.5, 1.5]);
+
+			group.addLayer(marker);
+			group.addLayer(marker2);
+			map.addLayer(group);
+
+			// Add event listener
+			group.on('spiderfied', function (event) {
+				expect(event.target).to.be(group);
+				expect(event.cluster).to.be.a(L.Marker);
+				expect(event.markers[1]).to.be(marker);
+				expect(event.markers[0]).to.be(marker2);
+
+				done();
+			});
+
+			marker.__parent.spiderfy();
+
+			clock.tick(200);
+		});
+
+		it('Spiderfies 2 Circles', function (done) {
+
+			var group = new L.MarkerClusterGroup();
+			var marker = new L.Circle([1.5, 1.5], 10);
+			var marker2 = new L.Circle([1.5, 1.5], 10);
+
+			group.addLayer(marker);
+			group.addLayer(marker2);
+			map.addLayer(group);
+
+			// Add event listener
+			group.on('spiderfied', function (event) {
+				expect(event.target).to.be(group);
+				expect(event.cluster).to.be.a(L.Marker);
+				expect(event.markers[1]).to.be(marker);
+				expect(event.markers[0]).to.be(marker2);
+
+				done();
+			});
+
+			marker.__parent.spiderfy();
+
+			clock.tick(200);
+		});
+	});
 });

--- a/spec/suites/spiderfySpec.js
+++ b/spec/suites/spiderfySpec.js
@@ -1,5 +1,6 @@
 ﻿describe('spiderfy', function () {
 	var map, div, clock;
+
 	beforeEach(function () {
 		clock = sinon.useFakeTimers();
 
@@ -15,6 +16,7 @@
 			[2, 2]
 		]));
 	});
+
 	afterEach(function () {
 		clock.restore();
 		document.body.removeChild(div);
@@ -141,4 +143,5 @@
 			clock.tick(200);
 		});
 	});
+
 });

--- a/src/MarkerCluster.Spiderfier.js
+++ b/src/MarkerCluster.Spiderfier.js
@@ -143,9 +143,9 @@ L.MarkerCluster.include(!L.DomUtil.TRANSITION ? {
 		}
 		this.setOpacity(0.3);
 		group.fire('spiderfied', {
-            cluster: this,
-            markers: childMarkers
-        });
+			cluster: this,
+			markers: childMarkers
+		});
 	},
 
 	_animationUnspiderfy: function () {
@@ -173,7 +173,7 @@ L.MarkerCluster.include(!L.DomUtil.TRANSITION ? {
 			if (m.setOpacity) {
 				m.setZIndexOffset(1000000); //Make these appear on top of EVERYTHING
 				m.setOpacity(0);
-			
+
 				fg.addLayer(m);
 
 				m._setPos(thisLayerPos);
@@ -197,7 +197,7 @@ L.MarkerCluster.include(!L.DomUtil.TRANSITION ? {
 			//Move marker to new position
 			m._preSpiderfyLatlng = m._latlng;
 			m.setLatLng(newPos);
-			
+
 			if (m.setOpacity) {
 				m.setOpacity(1);
 			}
@@ -260,9 +260,9 @@ L.MarkerCluster.include(!L.DomUtil.TRANSITION ? {
 		setTimeout(function () {
 			group._animationEnd();
 			group.fire('spiderfied', {
-                cluster: me,
-                markers: childMarkers
-            });
+				cluster: me,
+				markers: childMarkers
+			});
 		}, 200);
 	},
 

--- a/src/MarkerCluster.Spiderfier.js
+++ b/src/MarkerCluster.Spiderfier.js
@@ -142,7 +142,10 @@ L.MarkerCluster.include(!L.DomUtil.TRANSITION ? {
 			m._spiderLeg = leg;
 		}
 		this.setOpacity(0.3);
-		group.fire('spiderfied');
+		group.fire('spiderfied', {
+            cluster: this,
+            markers: childMarkers
+        });
 	},
 
 	_animationUnspiderfy: function () {
@@ -256,7 +259,10 @@ L.MarkerCluster.include(!L.DomUtil.TRANSITION ? {
 
 		setTimeout(function () {
 			group._animationEnd();
-			group.fire('spiderfied');
+			group.fire('spiderfied', {
+                cluster: me,
+                markers: childMarkers
+            });
 		}, 200);
 	},
 


### PR DESCRIPTION
When listening to the `spiderfied` event it's pretty hard to get the spiderfied context. The only provided context is target which is a reference of whole cluster object.

But only one marker with ist child markers got spiderfied, so it's helpful to provide this information when fire the event.