### PR TITLE
CommonJS+AMD support

### DIFF
--- a/build/umd.template
+++ b/build/umd.template
@@ -1,0 +1,39 @@
+//************************
+// Start UMD Header
+//************************
+(function (factory, window) {
+
+    var definedGlobally = false;
+    // attach your plugin to the global 'L' variable
+    if (typeof window !== 'undefined' && window.L) {
+        definedGlobally = true;
+        window.L.{{exportName}} = factory(window.L);
+    }
+
+    // define an AMD module that relies on 'leaflet'
+    if (typeof define === 'function' && define.amd) {
+        define(['leaflet'], factory);
+
+        // define a Common JS module that relies on 'leaflet'
+    } else if (typeof exports === 'object') {
+        module.exports.{{exportName}} = definedGlobally ?
+            window.L.{{exportName}} :
+            factory(require('leaflet'));
+    }
+
+}(function (L) {
+//************************
+// End UMD Header
+//************************
+
+    {{exportSource}}
+
+    return L.{{exportName}};
+
+//************************
+// Start UMD Footer
+//************************
+}, window));
+//************************
+// End UMD Footer
+//************************


### PR DESCRIPTION
OK, so this works for me..and the same number of tests fail with this change (21) as without. There wasn't an obvious/simple way (at least for me) to export `MarkerCluster.QuickHull` and `MarkerCluster.Spiderfier` so I didn't go there.