### PR TITLE
bower.json: ignore tests and examples.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,8 @@
         "**/.*",
         "node_modules",
         "bower_components",
+        "example",
+        "spec",
         "test",
         "tests"
     ],


### PR DESCRIPTION
Solves #462, reduces the bower distribution size ~7 times.