### PR TITLE
new spiderfy function

### DIFF
--- a/src/MarkerCluster.Spiderfier.js
+++ b/src/MarkerCluster.Spiderfier.js
@@ -30,12 +30,14 @@ L.MarkerCluster.include({
 
 		//TODO Maybe: childMarkers order by distance to center
 
-		if (childMarkers.length >= this._circleSpiralSwitchover) {
-			positions = this._generatePointsSpiral(childMarkers.length, center);
-		} else {
-			center.y += 10; //Otherwise circles look wrong
-			positions = this._generatePointsCircle(childMarkers.length, center);
-		}
+    if (childMarkers.length >= this._circleSpiralSwitchover) {
+      positions = this._generatePointsSpiral(childMarkers.length, center);
+    } else if (this._group.options.spiderfyLinear) { // checks for linear spiderfy
+      positions = this._generatePointsLine(childMarkers.length, center);
+    } else {
+      center.y += 10; //Otherwise circles look wrong
+      positions = this._generatePointsCircle(childMarkers.length, center);
+    }
 
 		this._animationSpiderfy(childMarkers, positions);
 	},
@@ -84,6 +86,24 @@ L.MarkerCluster.include({
 		}
 		return res;
 	},
+
+	_generatePointsLine: function (count, centerPt) {
+    var distanceFromCenter = this._group.options.spiderfyLinearDistance,
+        markerDistance = this._group.options.spiderfyLinearSeparation,
+        lineLength = markerDistance * (count - 1),
+        lineStart = centerPt.y - lineLength / 2,
+        res = [],
+        i;
+
+    res.length = count;
+
+    for (i = count - 1; i >= 0; i--) {
+      res[i] = new L.Point(centerPt.x + distanceFromCenter, lineStart + markerDistance * i);
+    }
+
+    return res;
+    
+  },
 
 	_noanimationUnspiderfy: function () {
 		var group = this._group,

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -26,6 +26,11 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		//Increase to increase the distance away that spiderfied markers appear from the center
 		spiderfyDistanceMultiplier: 1,
 
+		// Make it possible to create linear set of markers on spiderfy
+    spiderfyLinear: false,
+    spiderfyLinearDistance: 30, // negative numbers will go to the left of cluster
+    spiderfyLinearSeparation: 45, // works with leaflet default marker
+
 		// Make it possible to specify a polyline options on a spider leg
 		spiderLegPolylineOptions: { weight: 1.5, color: '#222' },
 


### PR DESCRIPTION
Hello! :wave: Per your comment in #467 I put together a function `_generatePointsLine()` in `MarkerCluster.spiderfy.js` that is invoked if the user passes `spiderfyLinear: true` in the MarkerClusterGroup parameters. Right now it just overrides `_generatePointsCircle()` and will still spiral if there are more markers than the `this._circleSpiralSwitchover` number.

This is a first-draft and there's no expectation of this becoming a full feature in the distributed version, but I figured I'd show what I ended up doing! This also requires some extra parameters and defaults in `src/MarkerClusterGroup.js` (probably too many new params?)

Here's a gif:
![spiderfylinear](https://cloud.githubusercontent.com/assets/1943001/6863879/4f75c310-d416-11e4-8a08-12f693eda720.gif)


Thanks :exclamation: 