### PR TITLE
Cluster aspect ratios.

### DIFF
--- a/src/DistanceGrid.js
+++ b/src/DistanceGrid.js
@@ -1,9 +1,11 @@
 
-L.DistanceGrid = function (cellSize) {
+L.DistanceGrid = function (cellSize, ratio) {
 	this._cellSize = cellSize;
+	this._aspectRatio = ratio;
+	this._invAspectRatio = 1 / ratio;
 	this._sqCellSize = cellSize * cellSize;
 	this._grid = {};
-	this._objectPoint = { };
+	this._objectPoint = {};
 };
 
 L.DistanceGrid.prototype = {
@@ -111,6 +113,6 @@ L.DistanceGrid.prototype = {
 	_sqDist: function (p, p2) {
 		var dx = p2.x - p.x,
 		    dy = p2.y - p.y;
-		return dx * dx + dy * dy;
+		return dx * dx * this._invAspectRatio + dy * dy * this._aspectRatio;
 	}
 };

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -6,6 +6,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 
 	options: {
 		maxClusterRadius: 80, //A cluster will cover at most this many pixels from its center
+		clusterAspectRatio: 1, // Horizontal radis = radius * sqrt(ratio); vertical = radius / sqrt(ratio)
 		iconCreateFunction: null,
 
 		spiderfyOnMaxZoom: true,
@@ -762,8 +763,8 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 	
 		//Set up DistanceGrids for each zoom
 		for (var zoom = maxZoom; zoom >= 0; zoom--) {
-			this._gridClusters[zoom] = new L.DistanceGrid(radiusFn(zoom));
-			this._gridUnclustered[zoom] = new L.DistanceGrid(radiusFn(zoom));
+			this._gridClusters[zoom] = new L.DistanceGrid(radiusFn(zoom), this.options.clusterAspectRatio);
+			this._gridUnclustered[zoom] = new L.DistanceGrid(radiusFn(zoom), this.options.clusterAspectRatio);
 		}
 
 		this._topClusterLevel = new L.MarkerCluster(this, -1);


### PR DESCRIPTION
Some of my layers are displayed just as text labels (which are much wider than they're tall, and clustering them using the classic cartesian distance doesn't make a lot of sense.

So, I changed a few things and now I can make wide or tall clusters. Rather simple, but works.