### PR TITLE
Limit Clusters by field values

### DIFF
--- a/src/DistanceGrid.js
+++ b/src/DistanceGrid.js
@@ -73,10 +73,12 @@ L.DistanceGrid.prototype = {
 		}
 	},
 
-	getNearObject: function (point) {
+	getNearObject: function (point, filter) {
 		var x = this._getCoord(point.x),
 		    y = this._getCoord(point.y),
-		    i, j, k, row, cell, len, obj, dist,
+		    i, j, k,
+		    l = false,
+		    row, cell, len, obj, dist,
 		    objectPoint = this._objectPoint,
 		    closestDistSq = this._sqCellSize,
 		    closest = null;
@@ -92,9 +94,23 @@ L.DistanceGrid.prototype = {
 						for (k = 0, len = cell.length; k < len; k++) {
 							obj = cell[k];
 							dist = this._sqDist(objectPoint[L.Util.stamp(obj)], point);
-							if (dist < closestDistSq) {
+							
+							//Start new stuff
+							function findAChild (obj) {
+								if( obj.feature ) {
+									return obj.feature.properties;
+								} if(obj._markers.length>0){
+									return findAChild(obj._markers[0]);
+								} else {
+									return findAChild(obj._childClusters[0]); 
+								}
+							}
+							l = findAChild(obj);
+							
+							if (l[filter[0]]===filter[1] && dist < closestDistSq) {
 								closestDistSq = dist;
 								closest = obj;
+								l=false;
 							}
 						}
 					}

--- a/src/DistanceGrid.js
+++ b/src/DistanceGrid.js
@@ -95,22 +95,12 @@ L.DistanceGrid.prototype = {
 							obj = cell[k];
 							dist = this._sqDist(objectPoint[L.Util.stamp(obj)], point);
 							
-							//Start new stuff
-							function findAChild (obj) {
-								if( obj.feature ) {
-									return obj.feature.properties;
-								} if(obj._markers.length>0){
-									return findAChild(obj._markers[0]);
-								} else {
-									return findAChild(obj._childClusters[0]); 
-								}
-							}
 							l = findAChild(obj);
 							
-							if (l[filter[0]]===filter[1] && dist < closestDistSq) {
+							if (l[filter[0]] === filter[1] && dist < closestDistSq) {
 								closestDistSq = dist;
 								closest = obj;
-								l=false;
+								l = false;
 							}
 						}
 					}
@@ -118,6 +108,16 @@ L.DistanceGrid.prototype = {
 			}
 		}
 		return closest;
+	},
+	
+	findAChild: function (obj) {
+		if (obj.feature) {
+			return obj.feature.properties;
+		} if (obj._markers.length>0){
+			return findAChild(obj._markers[0]);
+		} else {
+			return findAChild(obj._childClusters[0]); 
+		}
 	},
 
 	_getCoord: function (x) {

--- a/src/DistanceGrid.js
+++ b/src/DistanceGrid.js
@@ -95,7 +95,7 @@ L.DistanceGrid.prototype = {
 							obj = cell[k];
 							dist = this._sqDist(objectPoint[L.Util.stamp(obj)], point);
 							
-							l = findAChild(obj);
+							l = this._findAChild(obj);
 							
 							if (l[filter[0]] === filter[1] && dist < closestDistSq) {
 								closestDistSq = dist;
@@ -110,13 +110,13 @@ L.DistanceGrid.prototype = {
 		return closest;
 	},
 	
-	findAChild: function (obj) {
+	_findAChild: function (obj) {
 		if (obj.feature) {
 			return obj.feature.properties;
-		} if (obj._markers.length>0){
+		} else if (obj._markers.length > 0) {
 			return findAChild(obj._markers[0]);
 		} else {
-			return findAChild(obj._childClusters[0]); 
+			return findAChild(obj._childClusters[0]);
 		}
 	},
 

--- a/src/DistanceGrid.js
+++ b/src/DistanceGrid.js
@@ -114,9 +114,9 @@ L.DistanceGrid.prototype = {
 		if (obj.feature) {
 			return obj.feature.properties;
 		} else if (obj._markers.length > 0) {
-			return findAChild(obj._markers[0]);
+			return this._findAChild(obj._markers[0]);
 		} else {
-			return findAChild(obj._childClusters[0]);
+			return this._findAChild(obj._childClusters[0]);
 		}
 	},
 

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -6,6 +6,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 
 	options: {
 		maxClusterRadius: 80, //A cluster will cover at most this many pixels from its center
+		groupByCommonValues: null, //Pass a fieldname from feature.properties(Example: ZipCode) The field will be used to limit which markers can cluster. 
 		iconCreateFunction: null,
 
 		spiderfyOnMaxZoom: true,
@@ -773,6 +774,8 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 	_addLayer: function (layer, zoom) {
 		var gridClusters = this._gridClusters,
 		    gridUnclustered = this._gridUnclustered,
+		    GroupByVal = this.options.GroupByCommonValues,
+		    filter = [GroupByVal, layer.feature.properties[GroupByVal]],
 		    markerPoint, z;
 
 		if (this.options.singleMarkerMode) {
@@ -791,7 +794,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 			markerPoint = this._map.project(layer.getLatLng(), zoom); // calculate pixel position
 
 			//Try find a cluster close by
-			var closest = gridClusters[zoom].getNearObject(markerPoint);
+			var closest = gridClusters[zoom].getNearObject(markerPoint, filter);
 			if (closest) {
 				closest._addChild(layer);
 				layer.__parent = closest;
@@ -799,7 +802,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 			}
 
 			//Try find a marker close by to form a new cluster with
-			closest = gridUnclustered[zoom].getNearObject(markerPoint);
+			closest = gridUnclustered[zoom].getNearObject(markerPoint, filter);
 			if (closest) {
 				var parent = closest.__parent;
 				if (parent) {


### PR DESCRIPTION
This update allows users to specify a field when initializing the marker clusters which will be used when clustering points to limit which points can cluster with each other.  The field could be something like zip codes, neighborhood names, city names, etc.  Points will only cluster with other points if they share the same value in the field specified. 
