### PR TITLE
Change integer/string comparison in getLayer

### DIFF
--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -379,7 +379,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		var result = null;
 
 		this.eachLayer(function (l) {
-			if (L.stamp(l) === id) {
+			if (L.stamp(l) == id) {
 				result = l;
 			}
 		});

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -379,7 +379,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		var result = null;
 
 		this.eachLayer(function (l) {
-			if (L.stamp(l) == id) {
+			if (L.stamp(l) === parseInt(id, 10)) {
 				result = l;
 			}
 		});


### PR DESCRIPTION
Per issue #531 this comparison should be fixed since the id is a string and .stamp() assigns _leaflet_id as an integer.