### PR TITLE
getNearObject - found object is not residing in objectPoint

### DIFF
--- a/src/DistanceGrid.js
+++ b/src/DistanceGrid.js
@@ -91,10 +91,12 @@ L.DistanceGrid.prototype = {
 
 						for (k = 0, len = cell.length; k < len; k++) {
 							obj = cell[k];
-							dist = this._sqDist(objectPoint[L.Util.stamp(obj)], point);
-							if (dist < closestDistSq) {
-								closestDistSq = dist;
-								closest = obj;
+							if (objectPoint[L.Util.stamp(obj)]) {
+								dist = this._sqDist(objectPoint[L.Util.stamp(obj)], point);
+								if (dist < closestDistSq) {
+									closestDistSq = dist;
+									closest = obj;
+								}
 							}
 						}
 					}


### PR DESCRIPTION
I had the same issue as @AndrewEastwood in #105 where `Uncaught TypeError: Cannot read property 'x' of undefined`. Sometimes, `obj` resolves to an object which does not reside in `objectPoint`, which results in calculating the square distance of an undefined and a defined point (`point`).