### PR TITLE
Revert "Added "main" property to bower.json to make it compatible with wiredep"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
     "name": "leaflet.markercluster",
     "version": "0.4.0",
-    "main": "dist/leaflet.markercluster-src.js",
     "homepage": "https://github.com/Leaflet/Leaflet.markercluster",
     "authors": [
         "Dave Leaver <danzel@localhost.geek.nz>"


### PR DESCRIPTION
There was already a working and valid main section.

See [this issue](https://github.com/Leaflet/Leaflet.markercluster/issues/551)