### PR TITLE
Point to Leaflet master files and CartoDB tiles in examples

### DIFF
--- a/example/marker-clustering-convexhull.html
+++ b/example/marker-clustering-convexhull.html
@@ -3,8 +3,8 @@
 <head>
 	<title>Leaflet debug page</title>
 
-	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7/leaflet.css" />
-	<script src="http://cdn.leafletjs.com/leaflet-0.7/leaflet.js"></script>
+	<link href="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.css" rel="stylesheet" type="text/css" />
+	<script src="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.js"></script>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link rel="stylesheet" href="screen.css" />
 
@@ -20,12 +20,12 @@
 
 	<script type="text/javascript">
 
-		var cloudmadeUrl = 'http://{s}.tile.cloudmade.com/BC9A493B41014CAABB98F0471D759707/997/256/{z}/{x}/{y}.png',
-			cloudmadeAttribution = 'Map data &copy; 2011 OpenStreetMap contributors, Imagery &copy; 2011 CloudMade',
-			cloudmade = L.tileLayer(cloudmadeUrl, {maxZoom: 18, attribution: cloudmadeAttribution}),
+		var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+			}),
 			latlng = L.latLng(50.5, 30.51);
 
-		var map = L.map('map', {center: latlng, zoom: 15, layers: [cloudmade]});
+		var map = L.map('map', {center: latlng, zoom: 15, layers: [positron]});
 
 		var markers = L.markerClusterGroup({ spiderfyOnMaxZoom: false, showCoverageOnHover: false, zoomToBoundsOnClick: false });
 

--- a/example/marker-clustering-custom.html
+++ b/example/marker-clustering-custom.html
@@ -3,8 +3,8 @@
 <head>
 	<title>Leaflet debug page</title>
 
-	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7/leaflet.css" />
-	<script src="http://cdn.leafletjs.com/leaflet-0.7/leaflet.js"></script>
+	<link href="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.css" rel="stylesheet" type="text/css" />
+	<script src="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.js"></script>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link rel="stylesheet" href="screen.css" />
 	
@@ -28,12 +28,12 @@
 
 	<script type="text/javascript">
 
-		var cloudmadeUrl = 'http://{s}.tile.cloudmade.com/BC9A493B41014CAABB98F0471D759707/997/256/{z}/{x}/{y}.png',
-			cloudmadeAttribution = 'Map data &copy; 2011 OpenStreetMap contributors, Imagery &copy; 2011 CloudMade',
-			cloudmade = L.tileLayer(cloudmadeUrl, {maxZoom: 18, attribution: cloudmadeAttribution}),
+		var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+			}),
 			latlng = L.latLng(50.5, 30.51);
 
-		var map = L.map('map', {center: latlng, zoom: 15, layers: [cloudmade]});
+		var map = L.map('map', {center: latlng, zoom: 15, layers: [positron]});
 
 
 		//Custom radius and icon create function

--- a/example/marker-clustering-everything.html
+++ b/example/marker-clustering-everything.html
@@ -3,8 +3,8 @@
 <head>
 	<title>Leaflet debug page</title>
 
-	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7/leaflet.css" />
-	<script src="http://cdn.leafletjs.com/leaflet-0.7/leaflet.js"></script>
+	<link href="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.css" rel="stylesheet" type="text/css" />
+	<script src="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.js"></script>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link rel="stylesheet" href="screen.css" />
 
@@ -20,12 +20,12 @@
 	<span>Mouse over a cluster to see the bounds of its children and click a cluster to zoom to those bounds</span>
 	<script type="text/javascript">
 
-		var cloudmadeUrl = 'http://{s}.tile.cloudmade.com/BC9A493B41014CAABB98F0471D759707/997/256/{z}/{x}/{y}.png',
-			cloudmadeAttribution = 'Map data &copy; 2011 OpenStreetMap contributors, Imagery &copy; 2011 CloudMade',
-			cloudmade = L.tileLayer(cloudmadeUrl, {maxZoom: 18, attribution: cloudmadeAttribution}),
+		var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+			}),
 			latlng = L.latLng(50.5, 30.51);
 
-		var map = L.map('map', {center: latlng, zoom: 15, layers: [cloudmade]});
+		var map = L.map('map', {center: latlng, zoom: 15, layers: [positron]});
 
 		var markers = L.markerClusterGroup({ animateAddingMarkers : true });
 		var markersList = [];

--- a/example/marker-clustering-geojson.html
+++ b/example/marker-clustering-geojson.html
@@ -3,8 +3,8 @@
 <head>
 	<title>Leaflet debug page</title>
 
-	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7/leaflet.css" />
-	<script src="http://cdn.leafletjs.com/leaflet-0.7/leaflet.js"></script>
+	<link href="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.css" rel="stylesheet" type="text/css" />
+	<script src="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.js"></script>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link rel="stylesheet" href="screen.css" />
 
@@ -20,12 +20,12 @@
 	<span>Mouse over a cluster to see the bounds of its children and click a cluster to zoom to those bounds</span>
 	<script type="text/javascript">
 
-		var cloudmadeUrl = 'http://{s}.tile.cloudmade.com/BC9A493B41014CAABB98F0471D759707/997/256/{z}/{x}/{y}.png',
-			cloudmadeAttribution = 'Map data &copy; 2011 OpenStreetMap contributors, Imagery &copy; 2011 CloudMade, Points &copy 2012 LINZ',
-			cloudmade = L.tileLayer(cloudmadeUrl, {maxZoom: 17, attribution: cloudmadeAttribution}),
+		var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+			}),
 			latlng = L.latLng(0.78, 102.37);
 
-		var map = L.map('map', {center: latlng, zoom: 7, layers: [cloudmade]});
+		var map = L.map('map', {center: latlng, zoom: 7, layers: [positron]});
 
 		
 		var geojson = L.geoJson(geojsonSample, {

--- a/example/marker-clustering-realworld-maxzoom.388.html
+++ b/example/marker-clustering-realworld-maxzoom.388.html
@@ -3,8 +3,8 @@
 <head>
 	<title>Leaflet debug page</title>
 
-	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7/leaflet.css" />
-	<script src="http://cdn.leafletjs.com/leaflet-0.7/leaflet.js"></script>
+	<link href="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.css" rel="stylesheet" type="text/css" />
+	<script src="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.js"></script>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link rel="stylesheet" href="screen.css" />
 
@@ -20,12 +20,12 @@
 	<span>Markers will show on the bottom 2 zoom levels even though the markers would normally cluster.</span>
 	<script type="text/javascript">
 
-		var cloudmadeUrl = 'http://{s}.tile.cloudmade.com/BC9A493B41014CAABB98F0471D759707/997/256/{z}/{x}/{y}.png',
-			cloudmadeAttribution = 'Map data &copy; 2011 OpenStreetMap contributors, Imagery &copy; 2011 CloudMade, Points &copy 2012 LINZ',
-			cloudmade = L.tileLayer(cloudmadeUrl, {maxZoom: 17, attribution: cloudmadeAttribution}),
+		var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+			}),
 			latlng = L.latLng(-37.82, 175.24);
 
-		var map = L.map('map', {center: latlng, zoom: 13, layers: [cloudmade]});
+		var map = L.map('map', {center: latlng, zoom: 13, layers: [positron]});
 
 		var markers = L.markerClusterGroup({ disableClusteringAtZoom: 17 });
 		

--- a/example/marker-clustering-realworld-mobile.388.html
+++ b/example/marker-clustering-realworld-mobile.388.html
@@ -3,8 +3,8 @@
 <head>
 	<title>Leaflet debug page</title>
 
-	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7/leaflet.css" />
-	<script src="http://cdn.leafletjs.com/leaflet-0.7/leaflet.js"></script>
+	<link href="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.css" rel="stylesheet" type="text/css" />
+	<script src="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.js"></script>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<link rel="stylesheet" href="mobile.css" />
 
@@ -19,12 +19,12 @@
 
 	<script type="text/javascript">
 
-		var cloudmadeUrl = 'http://{s}.tile.cloudmade.com/BC9A493B41014CAABB98F0471D759707/997/256/{z}/{x}/{y}.png',
-			cloudmadeAttribution = 'Map data &copy; 2011 OpenStreetMap contributors, Imagery &copy; 2011 CloudMade, Points &copy 2012 LINZ',
-			cloudmade = L.tileLayer(cloudmadeUrl, {maxZoom: 18, attribution: cloudmadeAttribution}),
+		var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+			}),
 			latlng = L.latLng(-37.821, 175.22);
 
-		var map = L.map('map', {center: latlng, zoom: 15, layers: [cloudmade]});
+		var map = L.map('map', {center: latlng, zoom: 15, layers: [positron]});
 
 		var markers = L.markerClusterGroup();
 

--- a/example/marker-clustering-realworld.10000.html
+++ b/example/marker-clustering-realworld.10000.html
@@ -3,8 +3,8 @@
 <head>
 	<title>Leaflet debug page</title>
 
-	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7/leaflet.css" />
-	<script src="http://cdn.leafletjs.com/leaflet-0.7/leaflet.js"></script>
+	<link href="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.css" rel="stylesheet" type="text/css" />
+	<script src="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.js"></script>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link rel="stylesheet" href="screen.css" />
 
@@ -21,11 +21,11 @@
 	<span>Mouse over a cluster to see the bounds of its children and click a cluster to zoom to those bounds</span>
 	<script type="text/javascript">
 
-		var cloudmadeUrl = 'http://{s}.tile.cloudmade.com/BC9A493B41014CAABB98F0471D759707/997/256/{z}/{x}/{y}.png',
-			cloudmadeAttribution = 'Map data &copy; 2011 OpenStreetMap contributors, Imagery &copy; 2011 CloudMade, Points &copy 2012 LINZ',
-			cloudmade = L.tileLayer(cloudmadeUrl, {maxZoom: 17, attribution: cloudmadeAttribution}),
+		var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+			}),
 			latlng = L.latLng(-37.89, 175.46);
-		var map = L.map('map', {center: latlng, zoom: 13, layers: [cloudmade]});
+		var map = L.map('map', {center: latlng, zoom: 13, layers: [positron]});
 
 		var markers = L.markerClusterGroup({ chunkedLoading: true });
 		

--- a/example/marker-clustering-realworld.388.html
+++ b/example/marker-clustering-realworld.388.html
@@ -3,8 +3,8 @@
 <head>
 	<title>Leaflet debug page</title>
 
-	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7/leaflet.css" />
-	<script src="http://cdn.leafletjs.com/leaflet-0.7/leaflet.js"></script>
+	<link href="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.css" rel="stylesheet" type="text/css" />
+	<script src="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.js"></script>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link rel="stylesheet" href="screen.css" />
 
@@ -20,9 +20,9 @@
 	<span>Mouse over a cluster to see the bounds of its children and click a cluster to zoom to those bounds</span>
 	<script type="text/javascript">
 
-		var cloudmadeUrl = 'http://{s}.tile.cloudmade.com/BC9A493B41014CAABB98F0471D759707/997/256/{z}/{x}/{y}.png',
-			cloudmadeAttribution = 'Map data &copy; 2011 OpenStreetMap contributors, Imagery &copy; 2011 CloudMade, Points &copy 2012 LINZ',
-			cloudmade = L.tileLayer(cloudmadeUrl, {maxZoom: 17, attribution: cloudmadeAttribution}),
+		var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+			}),
 			latlng = L.latLng(-37.82, 175.24);
 
 		var map = L.map('map', {center: latlng, zoom: 13, layers: [cloudmade]});

--- a/example/marker-clustering-realworld.50000.html
+++ b/example/marker-clustering-realworld.50000.html
@@ -3,8 +3,8 @@
 <head>
 	<title>Leaflet debug page</title>
 
-	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7/leaflet.css" />
-	<script src="http://cdn.leafletjs.com/leaflet-0.7/leaflet.js"></script>
+	<link href="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.css" rel="stylesheet" type="text/css" />
+	<script src="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.js"></script>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link rel="stylesheet" href="screen.css" />
 
@@ -22,12 +22,12 @@
 	<div id="map"></div>
 	<span>Mouse over a cluster to see the bounds of its children and click a cluster to zoom to those bounds</span>
 	<script type="text/javascript">
-			var cloudmadeUrl = 'http://{s}.tile.cloudmade.com/BC9A493B41014CAABB98F0471D759707/997/256/{z}/{x}/{y}.png',
-			    cloudmadeAttribution = 'Map data &copy; 2011 OpenStreetMap contributors, Imagery &copy; 2011 CloudMade, Points &copy 2012 LINZ',
-			    cloudmade = L.tileLayer(cloudmadeUrl, { maxZoom: 17, attribution: cloudmadeAttribution }),
+			var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+				attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+			}),
 			    latlng = L.latLng(-37.79, 175.27);
 
-			var map = L.map('map', { center: latlng, zoom: 13, layers: [cloudmade] });
+			var map = L.map('map', { center: latlng, zoom: 13, layers: [positron] });
 
 			var progress = document.getElementById('progress');
 			var progressBar = document.getElementById('progress-bar');

--- a/example/marker-clustering-singlemarkermode.html
+++ b/example/marker-clustering-singlemarkermode.html
@@ -3,8 +3,8 @@
 <head>
 	<title>Leaflet debug page</title>
 
-	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7/leaflet.css" />
-	<script src="http://cdn.leafletjs.com/leaflet-0.7/leaflet.js"></script>
+	<link href="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.css" rel="stylesheet" type="text/css" />
+	<script src="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.js"></script>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link rel="stylesheet" href="screen.css" />
 
@@ -19,12 +19,12 @@
 
 	<script type="text/javascript">
 
-		var cloudmadeUrl = 'http://{s}.tile.cloudmade.com/BC9A493B41014CAABB98F0471D759707/997/256/{z}/{x}/{y}.png',
-			cloudmadeAttribution = 'Map data &copy; 2011 OpenStreetMap contributors, Imagery &copy; 2011 CloudMade',
-			cloudmade = L.tileLayer(cloudmadeUrl, {maxZoom: 18, attribution: cloudmadeAttribution}),
+		var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+			}),
 			latlng = L.latLng(50.5, 30.51);
 
-		var map = L.map('map', {center: latlng, zoom: 15, layers: [cloudmade]});
+		var map = L.map('map', {center: latlng, zoom: 15, layers: [positron]});
 
 		var markers = L.markerClusterGroup({ singleMarkerMode: true});
 

--- a/example/marker-clustering-spiderfier.html
+++ b/example/marker-clustering-spiderfier.html
@@ -3,8 +3,8 @@
 <head>
 	<title>Leaflet debug page</title>
 
-	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7/leaflet.css" />
-	<script src="http://cdn.leafletjs.com/leaflet-0.7/leaflet.js"></script>
+	<link href="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.css" rel="stylesheet" type="text/css" />
+	<script src="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.js"></script>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link rel="stylesheet" href="screen.css" />
 
@@ -20,12 +20,12 @@
 
 	<script type="text/javascript">
 
-		var cloudmadeUrl = 'http://{s}.tile.cloudmade.com/BC9A493B41014CAABB98F0471D759707/997/256/{z}/{x}/{y}.png',
-			cloudmadeAttribution = 'Map data &copy; 2011 OpenStreetMap contributors, Imagery &copy; 2011 CloudMade',
-			cloudmade = L.tileLayer(cloudmadeUrl, {maxZoom: 18, attribution: cloudmadeAttribution}),
+		var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+			}),
 			latlng = L.latLng(50.5, 30.51);
 
-		var map = L.map('map', {center: latlng, zoom: 15, layers: [cloudmade]});
+		var map = L.map('map', {center: latlng, zoom: 15, layers: [positron]});
 
 		var markers = L.markerClusterGroup({ spiderfyOnMaxZoom: false, showCoverageOnHover: false, zoomToBoundsOnClick: false });
 

--- a/example/marker-clustering-zoomtobounds.html
+++ b/example/marker-clustering-zoomtobounds.html
@@ -3,8 +3,8 @@
 <head>
 	<title>Leaflet debug page</title>
 
-	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7/leaflet.css" />
-	<script src="http://cdn.leafletjs.com/leaflet-0.7/leaflet.js"></script>
+	<link href="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.css" rel="stylesheet" type="text/css" />
+	<script src="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.js"></script>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link rel="stylesheet" href="screen.css" />
 
@@ -19,12 +19,12 @@
 
 	<script type="text/javascript">
 
-		var cloudmadeUrl = 'http://{s}.tile.cloudmade.com/BC9A493B41014CAABB98F0471D759707/997/256/{z}/{x}/{y}.png',
-			cloudmadeAttribution = 'Map data &copy; 2011 OpenStreetMap contributors, Imagery &copy; 2011 CloudMade',
-			cloudmade = L.tileLayer(cloudmadeUrl, {maxZoom: 18, attribution: cloudmadeAttribution}),
+		var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+			}),
 			latlng = L.latLng(50.5, 30.51);
 
-		var map = L.map('map', {center: latlng, zoom: 15, layers: [cloudmade]});
+		var map = L.map('map', {center: latlng, zoom: 15, layers: [positron]});
 
 		var markers = L.markerClusterGroup({spiderfyOnMaxZoom: false, showCoverageOnHover: false, zoomToBoundsOnClick: false});
 

--- a/example/marker-clustering-zoomtoshowlayer.html
+++ b/example/marker-clustering-zoomtoshowlayer.html
@@ -3,8 +3,8 @@
 <head>
 	<title>Leaflet debug page</title>
 
-	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7/leaflet.css" />
-	<script src="http://cdn.leafletjs.com/leaflet-0.7/leaflet.js"></script>
+	<link href="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.css" rel="stylesheet" type="text/css" />
+	<script src="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.js"></script>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link rel="stylesheet" href="screen.css" />
 
@@ -21,12 +21,12 @@
 	<span>When clicked we will zoom down to a marker, spiderfying if required to show it and then open its popup</span>
 	<script type="text/javascript">
 
-		var cloudmadeUrl = 'http://{s}.tile.cloudmade.com/BC9A493B41014CAABB98F0471D759707/997/256/{z}/{x}/{y}.png',
-			cloudmadeAttribution = 'Map data &copy; 2011 OpenStreetMap contributors, Imagery &copy; 2011 CloudMade, Points &copy 2012 LINZ',
-			cloudmade = L.tileLayer(cloudmadeUrl, {maxZoom: 17, attribution: cloudmadeAttribution}),
+		var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+			}),
 			latlng = L.latLng(-37.82, 175.24);
 
-		var map = L.map('map', {center: latlng, zoom: 13, layers: [cloudmade]});
+		var map = L.map('map', {center: latlng, zoom: 13, layers: [positron]});
 
 		var markers = L.markerClusterGroup();
 		var markerList = [];

--- a/example/marker-clustering.html
+++ b/example/marker-clustering.html
@@ -3,8 +3,8 @@
 <head>
 	<title>Leaflet debug page</title>
 
-	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7/leaflet.css" />
-	<script src="http://cdn.leafletjs.com/leaflet-0.7/leaflet.js"></script>
+	<link href="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.css" rel="stylesheet" type="text/css" />
+	<script src="https://leafletjs-cdn.s3.amazonaws.com/content/build/master/leaflet.js"></script>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link rel="stylesheet" href="screen.css" />
 
@@ -20,12 +20,12 @@
 
 	<script type="text/javascript">
 
-		var cloudmadeUrl = 'http://{s}.tile.cloudmade.com/BC9A493B41014CAABB98F0471D759707/997/256/{z}/{x}/{y}.png',
-			cloudmadeAttribution = 'Map data &copy; 2011 OpenStreetMap contributors, Imagery &copy; 2011 CloudMade',
-			cloudmade = new L.TileLayer(cloudmadeUrl, {maxZoom: 18, attribution: cloudmadeAttribution}),
+		var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+			}),
 			latlng = new L.LatLng(50.5, 30.51);
 
-		var map = new L.Map('map', {center: latlng, zoom: 15, layers: [cloudmade]});
+		var map = new L.Map('map', {center: latlng, zoom: 15, layers: [positron]});
 
 		var markers = new L.MarkerClusterGroup();
 		var markersList = [];


### PR DESCRIPTION
It makes little sense to point to the 0.7 Leaflet files and non-working Cloudmade tiles in the examples for `leaflet-master` branch.