### PR TITLE
Corrected typo in README for refreshClusters()

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,10 @@ If passing a second argument that evaluates to `true`, the method will also trig
 ```javascript
 // Use as many times as required to update markers,
 // then call refreshClusters once finished.
-for (i in markersArray) {
-	markersArray[i].refreshIconOptions(newOptionsMap);
+for (i in markersSubArray) {
+	markersSubArray[i].refreshIconOptions(newOptionsMappingArray[i]);
 }
-markers.refreshClusters(group);
+markers.refreshClusters(markersSubArray);
 
 // If updating only one marker, pass true to
 // refresh this marker's parent clusters right away.

--- a/README.md
+++ b/README.md
@@ -126,13 +126,12 @@ If you have [customized](#customising-the-clustered-markers) the clusters icon t
 You can use the method:
 - without arguments to force all cluster icons in the Marker Cluster Group to be re-drawn.
 - with an array or a mapping of markers to force only their parent clusters to be re-drawn.
-- with an L.MarkerClusterGroup, L.LayerGroup, or L.MarkerCluster. The method will look for all markers in these objects. Make sure they contain only markers which are also within this Marker Cluster Group.
+- with an L.LayerGroup or L.MarkerCluster. The method will look for all markers in these objects. Make sure they contain only markers which are also within this Marker Cluster Group.
 - with a single marker.
 ```javascript
 markers.refreshClusters();
 markers.refreshClusters([myMarker0, myMarker33]);
-markers.refreshClusters({id_0: myMarker0, id_any: myMarker33]);
-markers.refreshClusters(markers); // a Marker Cluster Group that contains all or a sub-set of this markers.
+markers.refreshClusters({id_0: myMarker0, id_any: myMarker33});
 markers.refreshClusters(myLayerGroup);
 markers.refreshClusters(myMarkerCluster);
 markers.refreshClusters(myMarker);
@@ -141,8 +140,16 @@ markers.refreshClusters(myMarker);
 The plugin also adds a method on L.Marker to easily update the underlying icon options and refresh the icon.
 If passing a second argument that evaluates to `true`, the method will also trigger a `refreshCluster` on the parent MarkerClusterGroup for that single marker.
 ```javascript
-myMarker.refreshIconOptions(optionsMap); // Use as many times as required to update markers, before calling refreshClusters.
-myMarker.refreshIconOptions(optionsMap, true); // Refreshes the marker's parent clusters right away.
+// Use as many times as required to update markers,
+// then call refreshClusters once finished.
+for (i in group) {
+	group[i].refreshIconOptions(newOptionsMap);
+}
+markers.refreshClusters(group);
+
+// If updating only one marker, pass true to
+// refresh this marker's parent clusters right away.
+myMarker.refreshIconOptions(optionsMap, true); 
 ```
 
 ### Adding and removing Markers

--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ If passing a second argument that evaluates to `true`, the method will also trig
 ```javascript
 // Use as many times as required to update markers,
 // then call refreshClusters once finished.
-for (i in group) {
-	group[i].refreshIconOptions(newOptionsMap);
+for (i in markersArray) {
+	markersArray[i].refreshIconOptions(newOptionsMap);
 }
 markers.refreshClusters(group);
 


### PR DESCRIPTION
Corrected typo on line 134 and slightly improved explanations about `refreshIconOptions()` method.
Improved clarity of example for `L.Marker.refreshIconOptions` method.