### PR TITLE
Added animate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Enabled by default (boolean options):
 * **zoomToBoundsOnClick**: When you click a cluster we zoom to its bounds.
 * **spiderfyOnMaxZoom**: When you click a cluster at the bottom zoom level we spiderfy it so you can see all of its markers. (*Note: the spiderfy occurs at the current zoom level if all items within the cluster are physically located at the same latitude and longitude.*)
 * **removeOutsideVisibleBounds**: Clusters and markers too far from the viewport are removed from the map for performance.
+* **animate**: Child markers and clusters smoothly split from / merge into clusters when zooming in / out. Also commands spiderfy animations. Defaults to false if `L.DomUtil.TRANSITION` is empty. If false, option `animateAddingMarkers` has no effect.
 
 Other options
 * **animateAddingMarkers**: If set to true then adding individual markers to the MarkerClusterGroup after it has been added to the map will add the marker and animate it in to the cluster. Defaults to false as this gives better performance when bulk adding markers. addLayers does not support this, only addLayer with individual Markers.

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ Enabled by default (boolean options):
 * **zoomToBoundsOnClick**: When you click a cluster we zoom to its bounds.
 * **spiderfyOnMaxZoom**: When you click a cluster at the bottom zoom level we spiderfy it so you can see all of its markers. (*Note: the spiderfy occurs at the current zoom level if all items within the cluster are physically located at the same latitude and longitude.*)
 * **removeOutsideVisibleBounds**: Clusters and markers too far from the viewport are removed from the map for performance.
-* **animate**: Child markers and clusters smoothly split from / merge into clusters when zooming in / out. Also commands spiderfy animations. Defaults to false if `L.DomUtil.TRANSITION` is empty. If false, option `animateAddingMarkers` has no effect.
+* **animate**: Smoothly split / merge clusters children when zooming and spiderfying. If `L.DomUtil.TRANSITION` is false, this option has no effect (no animation is possible).
 
 Other options
-* **animateAddingMarkers**: If set to true then adding individual markers to the MarkerClusterGroup after it has been added to the map will add the marker and animate it in to the cluster. Defaults to false as this gives better performance when bulk adding markers. addLayers does not support this, only addLayer with individual Markers.
+* **animateAddingMarkers**: If set to true (and `animate` option is also true) then adding individual markers to the MarkerClusterGroup after it has been added to the map will add the marker and animate it into the cluster. Defaults to false as this gives better performance when bulk adding markers. addLayers does not support this, only addLayer with individual Markers.
 * **disableClusteringAtZoom**: If set, at this zoom level and below markers will not be clustered. This defaults to disabled. [See Example](http://leaflet.github.com/Leaflet.markercluster/example/marker-clustering-realworld-maxzoom.388.html)
 * **maxClusterRadius**: The maximum radius that a cluster will cover from the central marker (in pixels). Default 80. Decreasing will make more, smaller clusters. You can also use a function that accepts the current map zoom and returns the maximum cluster radius in pixels.
 * **polygonOptions**: Options to pass when creating the L.Polygon(points, options) to show the bounds of a cluster

--- a/spec/index.html
+++ b/spec/index.html
@@ -36,6 +36,7 @@
 	<script type="text/javascript" src="suites/AddLayer.MultipleSpec.js"></script>
 	<script type="text/javascript" src="suites/AddLayer.SingleSpec.js"></script>
 	<script type="text/javascript" src="suites/AddLayersSpec.js"></script>
+	<script type="text/javascript" src="suites/animateOptionSpec.js"></script>
 
 	<script type="text/javascript" src="suites/ChildChangingIconSupportSpec.js"></script>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -62,6 +62,7 @@
 	<script type="text/javascript" src="suites/RememberOpacity.js"></script>
 
 	<script type="text/javascript" src="suites/RefreshSpec.js"></script>
+	<script type="text/javascript" src="suites/removeOutsideVisibleBoundsSpec.js"></script>
 
 	<script>
 		(window.mochaPhantomJS || window.mocha).run();

--- a/spec/suites/RefreshSpec.js
+++ b/spec/suites/RefreshSpec.js
@@ -1,5 +1,5 @@
 ﻿describe('refreshClusters', function () {
-	var map, div;
+	var map, div, clock, group;
 
 	function getClusterAtZoom(marker, zoom) {
 		var parent = marker.__parent;
@@ -11,43 +11,68 @@
 		return parent;
 	}
 
-	function expectClusterIconNeedsUpdate(marker, zoom, needsUpdate) {
-		var cluster = getClusterAtZoom(marker, zoom);
+	// It looks like using beforeEach and afterEach generates problems when
+	// total number (across all spec suites) of tests increases.
+	// It could be related to PhantomJS memory leak / bad garbage collection.
+	// This problem seems to affect only PhantomJS, no other browsers?
+	// So let's implement beforeEach and afterEach manually and try re-using objects.
 
-		expect(cluster._iconNeedsUpdate).to.be(needsUpdate);
-	}
+	div = document.createElement('div');
+	div.style.width = '200px';
+	div.style.height = '200px';
+	document.body.appendChild(div);
 
+	map = L.map(div, { maxZoom: 18 });
 
-	beforeEach(function () {
+	// Corresponds to zoom level 8 for the above div dimensions.
+	map.fitBounds(new L.LatLngBounds([
+		[1, 1],
+		[2, 2]
+	]));
+
+	function init() {
 		clock = sinon.useFakeTimers();
 
-		div = document.createElement('div');
-		div.style.width = '200px';
-		div.style.height = '200px';
-		document.body.appendChild(div);
+		// Look away to avoid refreshing the display while adding markers.
+		// By adding markers one by one (instead of using addLayers) we make
+		// sure we never start an async process.
+		map.fitBounds(new L.LatLngBounds([
+			[-11, -11],
+			[-10, -10]
+		]))
+	}
 
-		map = L.map(div, { maxZoom: 18 });
-
+	function setMapView() {
+		// Now look at the markers to force cluster icons drawing.
 		// Corresponds to zoom level 8 for the above div dimensions.
 		map.fitBounds(new L.LatLngBounds([
 			[1, 1],
 			[2, 2]
 		]));
-	});
-	afterEach(function () {
-		clock.restore();
+	}
 
-		document.body.removeChild(div);
-	});
+	function reset() {
+		// Keep map and div setup to avoid potential memory leak.
+		map.removeLayer(group);
+
+		// group must be thrown away since we are testing it with a potentially
+		// different configuration at each test.
+		group = null;
+
+		clock.restore();
+		clock = null;
+	}
 
 	it('flags all non-visible parent clusters of a given marker', function () {
 
-		var group = new L.MarkerClusterGroup();
-		var marker1 = new L.Marker([1.5, 1.5]);
-		var marker2 = new L.Marker([1.5, 1.5]);
+		init();
 
-		group.addLayers([marker1, marker2]);
-		map.addLayer(group);
+		group = L.markerClusterGroup().addTo(map);
+
+		var marker1 = L.marker([1.5, 1.5]).addTo(group),
+		    marker2 = L.marker([1.5, 1.5]).addTo(group); // Needed to force a cluster.
+
+		setMapView();
 
 		var marker1cluster10 = getClusterAtZoom(marker1, 10),
 		    marker1cluster2 = getClusterAtZoom(marker1, 2),
@@ -81,11 +106,15 @@
 		// Also check that visible clusters are "un-flagged" since they should be re-drawn.
 		expect(marker1cluster5._iconNeedsUpdate).to.not.be.ok();
 
+		reset();
+
 	});
 
 	it('re-draws visible clusters', function () {
 
-		var group = new L.MarkerClusterGroup({
+		init();
+
+		group = L.markerClusterGroup({
 			iconCreateFunction: function (cluster) {
 				var markers = cluster.getAllChildMarkers();
 
@@ -100,12 +129,12 @@
 					className: "original"
 				});
 			}
-		});
-		var marker1 = new L.Marker([1.5, 1.5]);
-		var marker2 = new L.Marker([1.5, 1.5]);
+		}).addTo(map);
 
-		group.addLayers([marker1, marker2]);
-		map.addLayer(group);
+		var marker1 = L.marker([1.5, 1.5]).addTo(group),
+		    marker2 = L.marker([1.5, 1.5]).addTo(group); // Needed to force a cluster.
+
+		setMapView();
 
 		var marker1cluster9 = getClusterAtZoom(marker1, 9);
 
@@ -130,32 +159,55 @@
 		expect(marker1cluster9._icon.className).to.contain("changed");
 		expect(marker1cluster9._icon.className).to.not.contain("original");
 
+		reset();
+
 	});
 
-	it('does not flag clusters of other markers', function () {
 
-		var group = new L.MarkerClusterGroup({
+	// Shared code for below tests.
+	var marker1 = L.marker([1.5, 1.5]),
+	    marker2 = L.marker([1.5, 1.5]), // Needed to force a cluster.
+	    marker3 = L.marker([1.1, 1.1]),
+	    marker4 = L.marker([1.1, 1.1]), // Needed to force a cluster.
+	    marker5 = L.marker([1.9, 1.9]),
+	    marker6 = L.marker([1.9, 1.9]), // Needed to force a cluster.
+	    marker1cluster8,
+	    marker1cluster3,
+	    marker1cluster5,
+	    marker3cluster8,
+	    marker3cluster3,
+	    marker3cluster5,
+	    marker5cluster8,
+	    marker5cluster3,
+	    marker5cluster5;
+
+	function init3clusterBranches() {
+
+		init();
+
+		group = L.markerClusterGroup({
 			maxClusterRadius: 2 // Make sure we keep distinct clusters.
-		});
-		var marker1 = new L.Marker([1.5, 1.5]);
-		var marker2 = new L.Marker([1.5, 1.5]);
-		var marker3 = new L.Marker([1.1, 1.1]);
-		var marker4 = new L.Marker([1.1, 1.1]);
-		var marker5 = new L.Marker([1.9, 1.9]);
-		var marker6 = new L.Marker([1.9, 1.9]);
+		}).addTo(map);
 
-		group.addLayers([marker1, marker2, marker3, marker4, marker5, marker6]);
-		map.addLayer(group);
+		// Populate Marker Cluster Group.
+		marker1.addTo(group);
+		marker2.addTo(group);
+		marker3.addTo(group);
+		marker4.addTo(group);
+		marker5.addTo(group);
+		marker6.addTo(group);
 
-		var marker1cluster8 = getClusterAtZoom(marker1, 8),
-		    marker1cluster3 = getClusterAtZoom(marker1, 3),
-		    marker1cluster5 = getClusterAtZoom(marker1, 5),
-		    marker3cluster8 = getClusterAtZoom(marker3, 8),
-		    marker3cluster3 = getClusterAtZoom(marker3, 3),
-		    marker3cluster5 = getClusterAtZoom(marker3, 5),
-		    marker5cluster8 = getClusterAtZoom(marker5, 8),
-		    marker5cluster3 = getClusterAtZoom(marker5, 3),
-		    marker5cluster5 = getClusterAtZoom(marker5, 5);
+		setMapView();
+
+		marker1cluster8 = getClusterAtZoom(marker1, 8);
+		marker1cluster3 = getClusterAtZoom(marker1, 3);
+		marker1cluster5 = getClusterAtZoom(marker1, 5);
+		marker3cluster8 = getClusterAtZoom(marker3, 8);
+		marker3cluster3 = getClusterAtZoom(marker3, 3);
+		marker3cluster5 = getClusterAtZoom(marker3, 5);
+		marker5cluster8 = getClusterAtZoom(marker5, 8);
+		marker5cluster3 = getClusterAtZoom(marker5, 3);
+		marker5cluster5 = getClusterAtZoom(marker5, 5);
 
 		// Make sure we have 3 distinct clusters up to zoom level Z (let's choose Z = 3)
 		expect(marker1cluster3._childCount).to.equal(2);
@@ -186,6 +238,13 @@
 
 		// Run any animation.
 		clock.tick(1000);
+
+		// Ready to refresh clusters with method of choice and assess result.
+	}
+
+	it('does not flag clusters of other markers', function () {
+
+		init3clusterBranches();
 
 		// Then request clusters refresh.
 		// No need to actually modify the marker.
@@ -201,62 +260,13 @@
 
 		expect(marker5cluster8._iconNeedsUpdate).to.not.be.ok();
 		expect(marker5cluster3._iconNeedsUpdate).to.not.be.ok();
+
+		reset();
 	});
 
 	it('processes itself when no argument is passed', function () {
 
-		var group = new L.MarkerClusterGroup({
-			maxClusterRadius: 2 // Make sure we keep distinct clusters.
-		});
-		var marker1 = new L.Marker([1.5, 1.5]);
-		var marker2 = new L.Marker([1.5, 1.5]);
-		var marker3 = new L.Marker([1.1, 1.1]);
-		var marker4 = new L.Marker([1.1, 1.1]);
-		var marker5 = new L.Marker([1.9, 1.9]);
-		var marker6 = new L.Marker([1.9, 1.9]);
-
-		group.addLayers([marker1, marker2, marker3, marker4, marker5, marker6]);
-		map.addLayer(group);
-
-		var marker1cluster8 = getClusterAtZoom(marker1, 8),
-		    marker1cluster3 = getClusterAtZoom(marker1, 3),
-		    marker1cluster5 = getClusterAtZoom(marker1, 5),
-		    marker3cluster8 = getClusterAtZoom(marker3, 8),
-		    marker3cluster3 = getClusterAtZoom(marker3, 3),
-		    marker3cluster5 = getClusterAtZoom(marker3, 5),
-		    marker5cluster8 = getClusterAtZoom(marker5, 8),
-		    marker5cluster3 = getClusterAtZoom(marker5, 3),
-		    marker5cluster5 = getClusterAtZoom(marker5, 5);
-
-		// Make sure we have 3 distinct clusters up to zoom level Z (let's choose Z = 3)
-		expect(marker1cluster3._childCount).to.equal(2);
-		expect(marker3cluster3._childCount).to.equal(2);
-		expect(marker5cluster3._childCount).to.equal(2);
-
-		// First go to some zoom levels so that Leaflet initializes clusters icons.
-		expect(marker1cluster8._iconNeedsUpdate).to.not.be.ok();
-		expect(marker3cluster8._iconNeedsUpdate).to.not.be.ok();
-		expect(marker5cluster8._iconNeedsUpdate).to.not.be.ok();
-
-		expect(marker1cluster3._iconNeedsUpdate).to.be.ok();
-		expect(marker3cluster3._iconNeedsUpdate).to.be.ok();
-		expect(marker5cluster3._iconNeedsUpdate).to.be.ok();
-		map.setZoom(3, {animate: false});
-		expect(marker1cluster3._iconNeedsUpdate).to.not.be.ok();
-		expect(marker3cluster3._iconNeedsUpdate).to.not.be.ok();
-		expect(marker5cluster3._iconNeedsUpdate).to.not.be.ok();
-
-		// Finish on an intermediate zoom level.
-		expect(marker1cluster5._iconNeedsUpdate).to.be.ok();
-		expect(marker3cluster5._iconNeedsUpdate).to.be.ok();
-		expect(marker5cluster5._iconNeedsUpdate).to.be.ok();
-		map.setZoom(5, {animate: false});
-		expect(marker1cluster5._iconNeedsUpdate).to.not.be.ok();
-		expect(marker3cluster5._iconNeedsUpdate).to.not.be.ok();
-		expect(marker5cluster5._iconNeedsUpdate).to.not.be.ok();
-
-		// Run any animation.
-		clock.tick(1000);
+		init3clusterBranches();
 
 		// Then request clusters refresh.
 		// No need to actually modify the marker.
@@ -272,62 +282,13 @@
 		expect(marker5cluster8._iconNeedsUpdate).to.be.ok();
 		expect(marker5cluster3._iconNeedsUpdate).to.be.ok();
 
+		reset();
+
 	});
 
 	it('accepts an array of markers', function () {
 
-		var group = new L.MarkerClusterGroup({
-			maxClusterRadius: 2 // Make sure we keep distinct clusters.
-		});
-		var marker1 = new L.Marker([1.5, 1.5]);
-		var marker2 = new L.Marker([1.5, 1.5]);
-		var marker3 = new L.Marker([1.1, 1.1]);
-		var marker4 = new L.Marker([1.1, 1.1]);
-		var marker5 = new L.Marker([1.9, 1.9]);
-		var marker6 = new L.Marker([1.9, 1.9]);
-
-		group.addLayers([marker1, marker2, marker3, marker4, marker5, marker6]);
-		map.addLayer(group);
-
-		var marker1cluster8 = getClusterAtZoom(marker1, 8),
-		    marker1cluster3 = getClusterAtZoom(marker1, 3),
-		    marker1cluster5 = getClusterAtZoom(marker1, 5),
-		    marker3cluster8 = getClusterAtZoom(marker3, 8),
-		    marker3cluster3 = getClusterAtZoom(marker3, 3),
-		    marker3cluster5 = getClusterAtZoom(marker3, 5),
-		    marker5cluster8 = getClusterAtZoom(marker5, 8),
-		    marker5cluster3 = getClusterAtZoom(marker5, 3),
-		    marker5cluster5 = getClusterAtZoom(marker5, 5);
-
-		// Make sure we have 3 distinct clusters up to zoom level Z (let's choose Z = 3)
-		expect(marker1cluster3._childCount).to.equal(2);
-		expect(marker3cluster3._childCount).to.equal(2);
-		expect(marker5cluster3._childCount).to.equal(2);
-
-		// First go to some zoom levels so that Leaflet initializes clusters icons.
-		expect(marker1cluster8._iconNeedsUpdate).to.not.be.ok();
-		expect(marker3cluster8._iconNeedsUpdate).to.not.be.ok();
-		expect(marker5cluster8._iconNeedsUpdate).to.not.be.ok();
-
-		expect(marker1cluster3._iconNeedsUpdate).to.be.ok();
-		expect(marker3cluster3._iconNeedsUpdate).to.be.ok();
-		expect(marker5cluster3._iconNeedsUpdate).to.be.ok();
-		map.setZoom(3, {animate: false});
-		expect(marker1cluster3._iconNeedsUpdate).to.not.be.ok();
-		expect(marker3cluster3._iconNeedsUpdate).to.not.be.ok();
-		expect(marker5cluster3._iconNeedsUpdate).to.not.be.ok();
-
-		// Finish on an intermediate zoom level.
-		expect(marker1cluster5._iconNeedsUpdate).to.be.ok();
-		expect(marker3cluster5._iconNeedsUpdate).to.be.ok();
-		expect(marker5cluster5._iconNeedsUpdate).to.be.ok();
-		map.setZoom(5, {animate: false});
-		expect(marker1cluster5._iconNeedsUpdate).to.not.be.ok();
-		expect(marker3cluster5._iconNeedsUpdate).to.not.be.ok();
-		expect(marker5cluster5._iconNeedsUpdate).to.not.be.ok();
-
-		// Run any animation.
-		clock.tick(1000);
+		init3clusterBranches();
 
 		// Then request clusters refresh.
 		// No need to actually modify the markers.
@@ -345,62 +306,13 @@
 		expect(marker3cluster8._iconNeedsUpdate).to.not.be.ok();
 		expect(marker3cluster3._iconNeedsUpdate).to.not.be.ok();
 
+		reset();
+
 	});
 
 	it('accepts a mapping of markers', function () {
 
-		var group = new L.MarkerClusterGroup({
-			maxClusterRadius: 2 // Make sure we keep distinct clusters.
-		});
-		var marker1 = new L.Marker([1.5, 1.5]);
-		var marker2 = new L.Marker([1.5, 1.5]);
-		var marker3 = new L.Marker([1.1, 1.1]);
-		var marker4 = new L.Marker([1.1, 1.1]);
-		var marker5 = new L.Marker([1.9, 1.9]);
-		var marker6 = new L.Marker([1.9, 1.9]);
-
-		group.addLayers([marker1, marker2, marker3, marker4, marker5, marker6]);
-		map.addLayer(group);
-
-		var marker1cluster8 = getClusterAtZoom(marker1, 8),
-		    marker1cluster3 = getClusterAtZoom(marker1, 3),
-		    marker1cluster5 = getClusterAtZoom(marker1, 5),
-		    marker3cluster8 = getClusterAtZoom(marker3, 8),
-		    marker3cluster3 = getClusterAtZoom(marker3, 3),
-		    marker3cluster5 = getClusterAtZoom(marker3, 5),
-		    marker5cluster8 = getClusterAtZoom(marker5, 8),
-		    marker5cluster3 = getClusterAtZoom(marker5, 3),
-		    marker5cluster5 = getClusterAtZoom(marker5, 5);
-
-		// Make sure we have 3 distinct clusters up to zoom level Z (let's choose Z = 3)
-		expect(marker1cluster3._childCount).to.equal(2);
-		expect(marker3cluster3._childCount).to.equal(2);
-		expect(marker5cluster3._childCount).to.equal(2);
-
-		// First go to some zoom levels so that Leaflet initializes clusters icons.
-		expect(marker1cluster8._iconNeedsUpdate).to.not.be.ok();
-		expect(marker3cluster8._iconNeedsUpdate).to.not.be.ok();
-		expect(marker5cluster8._iconNeedsUpdate).to.not.be.ok();
-
-		expect(marker1cluster3._iconNeedsUpdate).to.be.ok();
-		expect(marker3cluster3._iconNeedsUpdate).to.be.ok();
-		expect(marker5cluster3._iconNeedsUpdate).to.be.ok();
-		map.setZoom(3, {animate: false});
-		expect(marker1cluster3._iconNeedsUpdate).to.not.be.ok();
-		expect(marker3cluster3._iconNeedsUpdate).to.not.be.ok();
-		expect(marker5cluster3._iconNeedsUpdate).to.not.be.ok();
-
-		// Finish on an intermediate zoom level.
-		expect(marker1cluster5._iconNeedsUpdate).to.be.ok();
-		expect(marker3cluster5._iconNeedsUpdate).to.be.ok();
-		expect(marker5cluster5._iconNeedsUpdate).to.be.ok();
-		map.setZoom(5, {animate: false});
-		expect(marker1cluster5._iconNeedsUpdate).to.not.be.ok();
-		expect(marker3cluster5._iconNeedsUpdate).to.not.be.ok();
-		expect(marker5cluster5._iconNeedsUpdate).to.not.be.ok();
-
-		// Run any animation.
-		clock.tick(1000);
+		init3clusterBranches();
 
 		// Then request clusters refresh.
 		// No need to actually modify the markers.
@@ -420,62 +332,13 @@
 		expect(marker3cluster8._iconNeedsUpdate).to.not.be.ok();
 		expect(marker3cluster3._iconNeedsUpdate).to.not.be.ok();
 
+		reset();
+
 	});
 
 	it('accepts an L.LayerGroup', function () {
 
-		var group = new L.MarkerClusterGroup({
-			maxClusterRadius: 2 // Make sure we keep distinct clusters.
-		});
-		var marker1 = new L.Marker([1.5, 1.5]);
-		var marker2 = new L.Marker([1.5, 1.5]);
-		var marker3 = new L.Marker([1.1, 1.1]);
-		var marker4 = new L.Marker([1.1, 1.1]);
-		var marker5 = new L.Marker([1.9, 1.9]);
-		var marker6 = new L.Marker([1.9, 1.9]);
-
-		group.addLayers([marker1, marker2, marker3, marker4, marker5, marker6]);
-		map.addLayer(group);
-
-		var marker1cluster8 = getClusterAtZoom(marker1, 8),
-		    marker1cluster3 = getClusterAtZoom(marker1, 3),
-		    marker1cluster5 = getClusterAtZoom(marker1, 5),
-		    marker3cluster8 = getClusterAtZoom(marker3, 8),
-		    marker3cluster3 = getClusterAtZoom(marker3, 3),
-		    marker3cluster5 = getClusterAtZoom(marker3, 5),
-		    marker5cluster8 = getClusterAtZoom(marker5, 8),
-		    marker5cluster3 = getClusterAtZoom(marker5, 3),
-		    marker5cluster5 = getClusterAtZoom(marker5, 5);
-
-		// Make sure we have 3 distinct clusters up to zoom level Z (let's choose Z = 3)
-		expect(marker1cluster3._childCount).to.equal(2);
-		expect(marker3cluster3._childCount).to.equal(2);
-		expect(marker5cluster3._childCount).to.equal(2);
-
-		// First go to some zoom levels so that Leaflet initializes clusters icons.
-		expect(marker1cluster8._iconNeedsUpdate).to.not.be.ok();
-		expect(marker3cluster8._iconNeedsUpdate).to.not.be.ok();
-		expect(marker5cluster8._iconNeedsUpdate).to.not.be.ok();
-
-		expect(marker1cluster3._iconNeedsUpdate).to.be.ok();
-		expect(marker3cluster3._iconNeedsUpdate).to.be.ok();
-		expect(marker5cluster3._iconNeedsUpdate).to.be.ok();
-		map.setZoom(3, {animate: false});
-		expect(marker1cluster3._iconNeedsUpdate).to.not.be.ok();
-		expect(marker3cluster3._iconNeedsUpdate).to.not.be.ok();
-		expect(marker5cluster3._iconNeedsUpdate).to.not.be.ok();
-
-		// Finish on an intermediate zoom level.
-		expect(marker1cluster5._iconNeedsUpdate).to.be.ok();
-		expect(marker3cluster5._iconNeedsUpdate).to.be.ok();
-		expect(marker5cluster5._iconNeedsUpdate).to.be.ok();
-		map.setZoom(5, {animate: false});
-		expect(marker1cluster5._iconNeedsUpdate).to.not.be.ok();
-		expect(marker3cluster5._iconNeedsUpdate).to.not.be.ok();
-		expect(marker5cluster5._iconNeedsUpdate).to.not.be.ok();
-
-		// Run any animation.
-		clock.tick(1000);
+		init3clusterBranches();
 
 		// Then request clusters refresh.
 		// No need to actually modify the markers.
@@ -494,62 +357,13 @@
 		expect(marker3cluster8._iconNeedsUpdate).to.not.be.ok();
 		expect(marker3cluster3._iconNeedsUpdate).to.not.be.ok();
 
+		reset();
+
 	});
 
 	it('accepts an L.MarkerCluster', function () {
 
-		var group = new L.MarkerClusterGroup({
-			maxClusterRadius: 2 // Make sure we keep distinct clusters.
-		});
-		var marker1 = new L.Marker([1.5, 1.5]);
-		var marker2 = new L.Marker([1.5, 1.5]);
-		var marker3 = new L.Marker([1.1, 1.1]);
-		var marker4 = new L.Marker([1.1, 1.1]);
-		var marker5 = new L.Marker([1.9, 1.9]);
-		var marker6 = new L.Marker([1.9, 1.9]);
-
-		group.addLayers([marker1, marker2, marker3, marker4, marker5, marker6]);
-		map.addLayer(group);
-
-		var marker1cluster8 = getClusterAtZoom(marker1, 8),
-		    marker1cluster3 = getClusterAtZoom(marker1, 3),
-		    marker1cluster5 = getClusterAtZoom(marker1, 5),
-		    marker3cluster8 = getClusterAtZoom(marker3, 8),
-		    marker3cluster3 = getClusterAtZoom(marker3, 3),
-		    marker3cluster5 = getClusterAtZoom(marker3, 5),
-		    marker5cluster8 = getClusterAtZoom(marker5, 8),
-		    marker5cluster3 = getClusterAtZoom(marker5, 3),
-		    marker5cluster5 = getClusterAtZoom(marker5, 5);
-
-		// Make sure we have 3 distinct clusters up to zoom level Z (let's choose Z = 3)
-		expect(marker1cluster3._childCount).to.equal(2);
-		expect(marker3cluster3._childCount).to.equal(2);
-		expect(marker5cluster3._childCount).to.equal(2);
-
-		// First go to some zoom levels so that Leaflet initializes clusters icons.
-		expect(marker1cluster8._iconNeedsUpdate).to.not.be.ok();
-		expect(marker3cluster8._iconNeedsUpdate).to.not.be.ok();
-		expect(marker5cluster8._iconNeedsUpdate).to.not.be.ok();
-
-		expect(marker1cluster3._iconNeedsUpdate).to.be.ok();
-		expect(marker3cluster3._iconNeedsUpdate).to.be.ok();
-		expect(marker5cluster3._iconNeedsUpdate).to.be.ok();
-		map.setZoom(3, {animate: false});
-		expect(marker1cluster3._iconNeedsUpdate).to.not.be.ok();
-		expect(marker3cluster3._iconNeedsUpdate).to.not.be.ok();
-		expect(marker5cluster3._iconNeedsUpdate).to.not.be.ok();
-
-		// Finish on an intermediate zoom level.
-		expect(marker1cluster5._iconNeedsUpdate).to.be.ok();
-		expect(marker3cluster5._iconNeedsUpdate).to.be.ok();
-		expect(marker5cluster5._iconNeedsUpdate).to.be.ok();
-		map.setZoom(5, {animate: false});
-		expect(marker1cluster5._iconNeedsUpdate).to.not.be.ok();
-		expect(marker3cluster5._iconNeedsUpdate).to.not.be.ok();
-		expect(marker5cluster5._iconNeedsUpdate).to.not.be.ok();
-
-		// Run any animation.
-		clock.tick(1000);
+		init3clusterBranches();
 
 		// Then request clusters refresh.
 		// No need to actually modify the markers.
@@ -567,6 +381,12 @@
 		expect(marker5cluster8._iconNeedsUpdate).to.not.be.ok();
 		expect(marker5cluster3._iconNeedsUpdate).to.not.be.ok();
 
+		reset();
+
 	});
+
+	// Now we can throw away the map and div.
+	map.remove();
+	document.body.removeChild(div);
 
 });

--- a/spec/suites/animateOptionSpec.js
+++ b/spec/suites/animateOptionSpec.js
@@ -1,28 +1,105 @@
 describe('animate option', function () {
-	var map, div;
 
-	beforeEach(function () {
-		div = document.createElement('div');
-		div.style.width = '200px';
-		div.style.height = '200px';
-		document.body.appendChild(div);
+	/**
+	 * Wrapper for Mocha's `it` function, to avoid using `beforeEach` and `afterEach`
+	 * which create problems with PhantomJS when total number of tests (across all suites)
+	 * increases. Might be due to use of promises for which PhantomJS performs badly?
+	 * @param testDescription string
+	 * @param testInstructions function
+	 * @param testFinally function to be executed just before afterEach2, in the `finally` block.
+	 */
+	function it2(testDescription, testInstructions, testFinally) {
 
-		map = L.map(div, { maxZoom: 18 });
+		it(testDescription, function () {
 
-		// Corresponds to zoom level 8 for the above div dimensions.
-		map.fitBounds(new L.LatLngBounds([
-			[1, 1],
-			[2, 2]
-		]));
-	});
-	afterEach(function () {
-		document.body.removeChild(div);
-	});
+			// Before each test.
+			if (typeof beforeEach2 === "function") {
+				beforeEach2();
+			}
 
-	it('hooks animated methods version by default', function () {
+			try {
+
+				// Perform the actual test instructions.
+				testInstructions();
+
+			} catch (e) {
+
+				// Re-throw the exception so that Mocha sees the failed test.
+				throw e;
+
+			} finally {
+
+				// If specific final instructions are provided.
+				if (typeof testFinally === "function") {
+					testFinally();
+				}
+
+				// After each test.
+				if (typeof afterEach2 === "function") {
+					afterEach2();
+				}
+
+			}
+		});
+	}
+
+
+	/////////////////////////////
+	// SETUP FOR EACH TEST
+	/////////////////////////////
+
+	/**
+	 * Instructions to be executed before each test called with `it2`.
+	 */
+	function beforeEach2() {
+
+		// Nothing for this test suite.
+
+	}
+
+	/**
+	 * Instructions to be executed after each test called with `it2`.
+	 */
+	function afterEach2() {
+
+		if (group instanceof L.MarkerClusterGroup) {
+			group.removeLayers(group.getLayers());
+			map.removeLayer(group);
+		}
+
+		// Throw away group as it can be assigned with different configurations between tests.
+		group = null;
+	}
+
+
+	/////////////////////////////
+	// PREPARATION CODE
+	/////////////////////////////
+
+	var div, map, group;
+
+	div = document.createElement('div');
+	div.style.width = '200px';
+	div.style.height = '200px';
+	document.body.appendChild(div);
+
+	map = L.map(div, { maxZoom: 18 });
+
+	// Corresponds to zoom level 8 for the above div dimensions.
+	map.fitBounds(new L.LatLngBounds([
+		[1, 1],
+		[2, 2]
+	]));
+
+
+	/////////////////////////////
+	// TESTS
+	/////////////////////////////
+
+	it2('hooks animated methods version by default', function () {
 
 		// Need to add to map so that we have the top cluster level created.
-		var group = L.markerClusterGroup().addTo(map);
+		group = L.markerClusterGroup().addTo(map);
 
 		var withAnimation = L.MarkerClusterGroup.prototype._withAnimation;
 
@@ -42,10 +119,10 @@ describe('animate option', function () {
 
 	});
 
-	it('hooks non-animated methods version when set to false', function () {
+	it2('hooks non-animated methods version when set to false', function () {
 
 		// Need to add to map so that we have the top cluster level created.
-		var group = L.markerClusterGroup({animate: false}).addTo(map);
+		group = L.markerClusterGroup({animate: false}).addTo(map);
 
 		var noAnimation = L.MarkerClusterGroup.prototype._noAnimation;
 
@@ -64,5 +141,13 @@ describe('animate option', function () {
 		expect(cluster._animationUnspiderfy).to.be(noAnimation._animationUnspiderfy);
 
 	});
+
+
+	/////////////////////////////
+	// CLEAN UP CODE
+	/////////////////////////////
+
+	map.remove();
+	document.body.removeChild(div);
 
 });

--- a/spec/suites/animateOptionSpec.js
+++ b/spec/suites/animateOptionSpec.js
@@ -1,0 +1,68 @@
+describe('animate option', function () {
+	var map, div;
+
+	beforeEach(function () {
+		div = document.createElement('div');
+		div.style.width = '200px';
+		div.style.height = '200px';
+		document.body.appendChild(div);
+
+		map = L.map(div, { maxZoom: 18 });
+
+		// Corresponds to zoom level 8 for the above div dimensions.
+		map.fitBounds(new L.LatLngBounds([
+			[1, 1],
+			[2, 2]
+		]));
+	});
+	afterEach(function () {
+		document.body.removeChild(div);
+	});
+
+	it('hooks animated methods version by default', function () {
+
+		// Need to add to map so that we have the top cluster level created.
+		var group = L.markerClusterGroup().addTo(map);
+
+		var withAnimation = L.MarkerClusterGroup.prototype._withAnimation;
+
+		// MCG animated methods.
+		expect(group._animationStart).to.be(withAnimation._animationStart);
+		expect(group._animationZoomIn).to.be(withAnimation._animationZoomIn);
+		expect(group._animationZoomOut).to.be(withAnimation._animationZoomOut);
+		expect(group._animationAddLayer).to.be(withAnimation._animationAddLayer);
+
+		// MarkerCluster spiderfy animated methods
+		var cluster = group._topClusterLevel;
+
+		withAnimation = L.MarkerCluster.prototype;
+
+		expect(cluster._animationSpiderfy).to.be(withAnimation._animationSpiderfy);
+		expect(cluster._animationUnspiderfy).to.be(withAnimation._animationUnspiderfy);
+
+	});
+
+	it('hooks non-animated methods version when set to false', function () {
+
+		// Need to add to map so that we have the top cluster level created.
+		var group = L.markerClusterGroup({animate: false}).addTo(map);
+
+		var noAnimation = L.MarkerClusterGroup.prototype._noAnimation;
+
+		// MCG non-animated methods.
+		expect(group._animationStart).to.be(noAnimation._animationStart);
+		expect(group._animationZoomIn).to.be(noAnimation._animationZoomIn);
+		expect(group._animationZoomOut).to.be(noAnimation._animationZoomOut);
+		expect(group._animationAddLayer).to.be(noAnimation._animationAddLayer);
+
+		// MarkerCluster spiderfy non-animated methods
+		var cluster = group._topClusterLevel;
+
+		noAnimation = L.MarkerClusterNonAnimated.prototype;
+
+		expect(cluster._animationSpiderfy).to.be(noAnimation._animationSpiderfy);
+		expect(cluster._animationUnspiderfy).to.be(noAnimation._animationUnspiderfy);
+
+	});
+
+});

--- a/spec/suites/removeOutsideVisibleBoundsSpec.js
+++ b/spec/suites/removeOutsideVisibleBoundsSpec.js
@@ -1,0 +1,185 @@
+describe('Option removeOutsideVisibleBounds', function () {
+
+	/**
+	 * Wrapper for Mocha's `it` function, to avoid using `beforeEach` and `afterEach`
+	 * which create problems with PhantomJS when total number of tests (across all suites)
+	 * increases. Might be due to use of promises for which PhantomJS performs badly?
+	 * @param testDescription string
+	 * @param testInstructions function
+	 * @param testFinally function to be executed just before afterEach2, in the `finally` block.
+	 */
+	function it2(testDescription, testInstructions, testFinally) {
+
+		it(testDescription, function () {
+
+			// Before each test.
+			if (typeof beforeEach2 === "function") {
+				beforeEach2();
+			}
+
+			try {
+
+				// Perform the actual test instructions.
+				testInstructions();
+
+			} catch (e) {
+
+				// Re-throw the exception so that Mocha sees the failed test.
+				throw e;
+
+			} finally {
+
+				// If specific final instructions are provided.
+				if (typeof testFinally === "function") {
+					testFinally();
+				}
+
+				// After each test.
+				if (typeof afterEach2 === "function") {
+					afterEach2();
+				}
+
+			}
+		});
+	}
+
+
+	/////////////////////////////
+	// SETUP FOR EACH TEST
+	/////////////////////////////
+
+	/**
+	 * Instructions to be executed before each test called with `it2`.
+	 */
+	function beforeEach2() {
+
+		// Nothing for this test suite.
+
+	}
+
+	/**
+	 * Instructions to be executed after each test called with `it2`.
+	 */
+	function afterEach2() {
+
+		if (group instanceof L.MarkerClusterGroup) {
+			group.removeLayers(group.getLayers());
+			map.removeLayer(group);
+		}
+
+		// Throw away group as it can be assigned with different configurations between tests.
+		group = null;
+	}
+
+
+	/////////////////////////////
+	// PREPARATION CODE
+	/////////////////////////////
+
+	var marker1 = L.marker([1.5, -0.4]), // 2 screens width away.
+	    marker2 = L.marker([1.5, 0.6]), // 1 screen width away.
+	    marker3 = L.marker([1.5, 1.5]), // In view port.
+	    marker4 = L.marker([1.5, 2.4]), // 1 screen width away.
+	    marker5 = L.marker([1.5, 3.4]), // 2 screens width away.
+	    div, map, group, previousMobileSetting;
+
+	div = document.createElement('div');
+	div.style.width = '200px';
+	div.style.height = '200px';
+	document.body.appendChild(div);
+
+	map = L.map(div, { maxZoom: 18 });
+
+	// Corresponds to zoom level 8 for the above div dimensions.
+	map.fitBounds(new L.LatLngBounds([
+		[1, 1],
+		[2, 2]
+	]));
+
+	// Add all markers once to map then remove them immediately so that their icon is null (instead of undefined).
+	map.removeLayer(marker1.addTo(map));
+	map.removeLayer(marker2.addTo(map));
+	map.removeLayer(marker3.addTo(map));
+	map.removeLayer(marker4.addTo(map));
+	map.removeLayer(marker5.addTo(map));
+
+
+	function prepareGroup() {
+
+		// Group should be assigned with a Marker Cluster Group before calling this function.
+		group.addTo(map);
+
+		// Add markers 1 by 1 to make sure we do not create an async process.
+		marker1.addTo(group);
+		marker2.addTo(group);
+		marker3.addTo(group);
+		marker4.addTo(group);
+		marker5.addTo(group);
+	}
+
+
+	/////////////////////////////
+	// TESTS
+	/////////////////////////////
+
+	it2('removes objects more than 1 screen away from view port by default', function () {
+
+		group = L.markerClusterGroup();
+
+		prepareGroup();
+
+		expect(marker1._icon).to.be(null);
+		expect(map._panes.markerPane.childNodes.length).to.be(3); // markers 2, 3 and 4.
+		expect(marker5._icon).to.be(null);
+
+	});
+
+	it2(
+		'removes objects out of view port by default for mobile device',
+
+		function () {
+
+			// Fool Leaflet, make it thinks it runs on a mobile device.
+			previousMobileSetting = L.Browser.mobile;
+			L.Browser.mobile = true;
+
+			group = L.markerClusterGroup();
+
+			prepareGroup();
+
+			expect(marker1._icon).to.be(null);
+			expect(marker2._icon).to.be(null);
+			expect(map._panes.markerPane.childNodes.length).to.be(1); // marker 3 only.
+			expect(marker4._icon).to.be(null);
+			expect(marker5._icon).to.be(null);
+
+		},
+
+		// Extra final instruction to be called even on failure.
+		function () {
+			// Restore original setting, so that next tests are unaffected.
+			L.Browser.mobile = previousMobileSetting;
+		}
+	);
+
+	it2('leaves all objects on map when set to false', function () {
+
+		group = L.markerClusterGroup({
+			removeOutsideVisibleBounds: false
+		});
+
+		prepareGroup();
+
+		expect(map._panes.markerPane.childNodes.length).to.be(5); // All 5 markers.
+
+	});
+
+
+	/////////////////////////////
+	// CLEAN UP CODE
+	/////////////////////////////
+
+	map.remove();
+	document.body.removeChild(div);
+
+});

--- a/src/MarkerCluster.Spiderfier.js
+++ b/src/MarkerCluster.Spiderfier.js
@@ -116,13 +116,13 @@ L.MarkerCluster.include({
 	}
 });
 
-L.MarkerCluster.include(!L.DomUtil.TRANSITION ? {
+L.MarkerClusterNonAnimated = L.MarkerCluster.extend({
 	//Non Animated versions of everything
 	_animationSpiderfy: function (childMarkers, positions) {
 		var group = this._group,
-			map = group._map,
-			fg = group._featureGroup,
-			i, m, leg, newPos;
+		    map = group._map,
+		    fg = group._featureGroup,
+		    i, m, leg, newPos;
 
 		for (i = childMarkers.length - 1; i >= 0; i--) {
 			newPos = map.layerPointToLatLng(positions[i]);
@@ -148,7 +148,9 @@ L.MarkerCluster.include(!L.DomUtil.TRANSITION ? {
 	_animationUnspiderfy: function () {
 		this._noanimationUnspiderfy();
 	}
-} : {
+});
+
+L.MarkerCluster.include({
 	//Animated versions here
 	SVG_ANIMATION: (function () {
 		return document.createElementNS('http://www.w3.org/2000/svg', 'animate').toString().indexOf('SVGAnimate') > -1;

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -63,12 +63,8 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		this._queue = [];
 
 		// Hook the appropriate animation methods.
-		//var animationMode = this.options.animate ? this._withAnimation : this._noAnimation;
 		L.extend(this, this.options.animate ? this._withAnimation : this._noAnimation);
-		/*this._animationStart = animationMode._animationStart;
-		this._animationZoomIn = animationMode._animationZoomIn;
-		this._animationZoomOut = animationMode._animationZoomOut;
-		this._animationAddLayer = animationMode._animationAddLayer;*/
+		// Remember which MarkerCluster class to instantiate (animated or not).
 		this._markerCluster = this.options.animate ? L.MarkerCluster : L.MarkerClusterNonAnimated;
 	},
 

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -19,6 +19,9 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		// is the default behaviour for performance reasons.
 		removeOutsideVisibleBounds: true,
 
+		// Set to false to disable all animations. If false, option animateAddingMarkers below has no effect.
+		animate: L.DomUtil.TRANSITION,
+
 		//Whether to animate adding markers after adding the MarkerClusterGroup to the map
 		// If you are adding individual markers set to true, if adding bulk markers leave false for massive performance gains.
 		animateAddingMarkers: false,
@@ -58,6 +61,15 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		this._currentShownBounds = null;
 
 		this._queue = [];
+
+		// Hook the appropriate animation methods.
+		//var animationMode = this.options.animate ? this._withAnimation : this._noAnimation;
+		L.extend(this, this.options.animate ? this._withAnimation : this._noAnimation);
+		/*this._animationStart = animationMode._animationStart;
+		this._animationZoomIn = animationMode._animationZoomIn;
+		this._animationZoomOut = animationMode._animationZoomOut;
+		this._animationAddLayer = animationMode._animationAddLayer;*/
+		this._markerCluster = this.options.animate ? L.MarkerCluster : L.MarkerClusterNonAnimated;
 	},
 
 	addLayer: function (layer) {
@@ -772,7 +784,8 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 			this._gridUnclustered[zoom] = new L.DistanceGrid(radiusFn(zoom));
 		}
 
-		this._topClusterLevel = new L.MarkerCluster(this, -1);
+		this._topClusterLevel = new this._markerCluster(this, -1);
+		//this._topClusterLevel = new L.MarkerCluster(this, -1);
 	},
 
 	//Zoom: Zoom to start adding at (Pass this._maxZoom to start at the bottom)
@@ -814,7 +827,8 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 
 				//Create new cluster with these 2 in it
 
-				var newCluster = new L.MarkerCluster(this, zoom, closest, layer);
+				var newCluster = new this._markerCluster(this, zoom, closest, layer);
+				//var newCluster = new L.MarkerCluster(this, zoom, closest, layer);
 				gridClusters[zoom].addObject(newCluster, this._map.project(newCluster._cLatLng, zoom));
 				closest.__parent = newCluster;
 				layer.__parent = newCluster;
@@ -822,7 +836,8 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 				//First create any new intermediate parent clusters that don't exist
 				var lastParent = newCluster;
 				for (z = zoom - 1; z > parent._zoom; z--) {
-					lastParent = new L.MarkerCluster(this, z, lastParent);
+					lastParent = new this._markerCluster(this, z, lastParent);
+					//lastParent = new L.MarkerCluster(this, z, lastParent);
 					gridClusters[z].addObject(lastParent, this._map.project(closest.getLatLng(), z));
 				}
 				parent._addChild(lastParent);
@@ -919,114 +934,140 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 	}
 });
 
-L.MarkerClusterGroup.include(!L.DomUtil.TRANSITION ? {
+L.MarkerClusterGroup.include({
+	_noAnimation: {
+		//Non Animated versions of everything
+		_animationStart: function () {
+			//Do nothing...
+		},
+		_animationZoomIn: function (previousZoomLevel, newZoomLevel) {
+			this._topClusterLevel._recursivelyRemoveChildrenFromMap(this._currentShownBounds, previousZoomLevel);
+			this._topClusterLevel._recursivelyAddChildrenToMap(null, newZoomLevel, this._getExpandedVisibleBounds());
 
-	//Non Animated versions of everything
-	_animationStart: function () {
-		//Do nothing...
-	},
-	_animationZoomIn: function (previousZoomLevel, newZoomLevel) {
-		this._topClusterLevel._recursivelyRemoveChildrenFromMap(this._currentShownBounds, previousZoomLevel);
-		this._topClusterLevel._recursivelyAddChildrenToMap(null, newZoomLevel, this._getExpandedVisibleBounds());
+			//We didn't actually animate, but we use this event to mean "clustering animations have finished"
+			this.fire('animationend');
+		},
+		_animationZoomOut: function (previousZoomLevel, newZoomLevel) {
+			this._topClusterLevel._recursivelyRemoveChildrenFromMap(this._currentShownBounds, previousZoomLevel);
+			this._topClusterLevel._recursivelyAddChildrenToMap(null, newZoomLevel, this._getExpandedVisibleBounds());
 
-		//We didn't actually animate, but we use this event to mean "clustering animations have finished"
-		this.fire('animationend');
-	},
-	_animationZoomOut: function (previousZoomLevel, newZoomLevel) {
-		this._topClusterLevel._recursivelyRemoveChildrenFromMap(this._currentShownBounds, previousZoomLevel);
-		this._topClusterLevel._recursivelyAddChildrenToMap(null, newZoomLevel, this._getExpandedVisibleBounds());
-
-		//We didn't actually animate, but we use this event to mean "clustering animations have finished"
-		this.fire('animationend');
-	},
-	_animationAddLayer: function (layer, newCluster) {
-		this._animationAddLayerNonAnimated(layer, newCluster);
-	}
-} : {
-
-	//Animated versions here
-	_animationStart: function () {
-		this._map._mapPane.className += ' leaflet-cluster-anim';
-		this._inZoomAnimation++;
-	},
-	_animationEnd: function () {
-		if (this._map) {
-			this._map._mapPane.className = this._map._mapPane.className.replace(' leaflet-cluster-anim', '');
+			//We didn't actually animate, but we use this event to mean "clustering animations have finished"
+			this.fire('animationend');
+		},
+		_animationAddLayer: function (layer, newCluster) {
+			this._animationAddLayerNonAnimated(layer, newCluster);
 		}
-		this._inZoomAnimation--;
-		this.fire('animationend');
 	},
-	_animationZoomIn: function (previousZoomLevel, newZoomLevel) {
-		var bounds = this._getExpandedVisibleBounds(),
-		    fg = this._featureGroup,
-		    i;
+	_withAnimation: {
+		//Animated versions here
+		_animationStart: function () {
+			this._map._mapPane.className += ' leaflet-cluster-anim';
+			this._inZoomAnimation++;
+		},
+		_animationZoomIn: function (previousZoomLevel, newZoomLevel) {
+			var bounds = this._getExpandedVisibleBounds(),
+			    fg     = this._featureGroup,
+			    i;
 
-		//Add all children of current clusters to map and remove those clusters from map
-		this._topClusterLevel._recursively(bounds, previousZoomLevel, 0, function (c) {
-			var startPos = c._latlng,
-				markers = c._markers,
-				m;
-
-			if (!bounds.contains(startPos)) {
-				startPos = null;
-			}
-
-			if (c._isSingleParent() && previousZoomLevel + 1 === newZoomLevel) { //Immediately add the new child and remove us
-				fg.removeLayer(c);
-				c._recursivelyAddChildrenToMap(null, newZoomLevel, bounds);
-			} else {
-				//Fade out old cluster
-				c.clusterHide();
-				c._recursivelyAddChildrenToMap(startPos, newZoomLevel, bounds);
-			}
-
-			//Remove all markers that aren't visible any more
-			//TODO: Do we actually need to do this on the higher levels too?
-			for (i = markers.length - 1; i >= 0; i--) {
-				m = markers[i];
-				if (!bounds.contains(m._latlng)) {
-					fg.removeLayer(m);
-				}
-			}
-
-		});
-
-		this._forceLayout();
-
-		//Update opacities
-		this._topClusterLevel._recursivelyBecomeVisible(bounds, newZoomLevel);
-		//TODO Maybe? Update markers in _recursivelyBecomeVisible
-		fg.eachLayer(function (n) {
-			if (!(n instanceof L.MarkerCluster) && n._icon) {
-				n.clusterShow();
-			}
-		});
-
-		//update the positions of the just added clusters/markers
-		this._topClusterLevel._recursively(bounds, previousZoomLevel, newZoomLevel, function (c) {
-			c._recursivelyRestoreChildPositions(newZoomLevel);
-		});
-
-		//Remove the old clusters and close the zoom animation
-		this._enqueue(function () {
-			//update the positions of the just added clusters/markers
+			//Add all children of current clusters to map and remove those clusters from map
 			this._topClusterLevel._recursively(bounds, previousZoomLevel, 0, function (c) {
-				fg.removeLayer(c);
-				c.clusterShow();
+				var startPos = c._latlng,
+				    markers  = c._markers,
+				    m;
+
+				if (!bounds.contains(startPos)) {
+					startPos = null;
+				}
+
+				if (c._isSingleParent() && previousZoomLevel + 1 === newZoomLevel) { //Immediately add the new child and remove us
+					fg.removeLayer(c);
+					c._recursivelyAddChildrenToMap(null, newZoomLevel, bounds);
+				} else {
+					//Fade out old cluster
+					c.clusterHide();
+					c._recursivelyAddChildrenToMap(startPos, newZoomLevel, bounds);
+				}
+
+				//Remove all markers that aren't visible any more
+				//TODO: Do we actually need to do this on the higher levels too?
+				for (i = markers.length - 1; i >= 0; i--) {
+					m = markers[i];
+					if (!bounds.contains(m._latlng)) {
+						fg.removeLayer(m);
+					}
+				}
+
 			});
 
-			this._animationEnd();
-		});
+			this._forceLayout();
+
+			//Update opacities
+			this._topClusterLevel._recursivelyBecomeVisible(bounds, newZoomLevel);
+			//TODO Maybe? Update markers in _recursivelyBecomeVisible
+			fg.eachLayer(function (n) {
+				if (!(n instanceof L.MarkerCluster) && n._icon) {
+					n.clusterShow();
+				}
+			});
+
+			//update the positions of the just added clusters/markers
+			this._topClusterLevel._recursively(bounds, previousZoomLevel, newZoomLevel, function (c) {
+				c._recursivelyRestoreChildPositions(newZoomLevel);
+			});
+
+			//Remove the old clusters and close the zoom animation
+			this._enqueue(function () {
+				//update the positions of the just added clusters/markers
+				this._topClusterLevel._recursively(bounds, previousZoomLevel, 0, function (c) {
+					fg.removeLayer(c);
+					c.clusterShow();
+				});
+
+				this._animationEnd();
+			});
+		},
+
+		_animationZoomOut: function (previousZoomLevel, newZoomLevel) {
+			this._animationZoomOutSingle(this._topClusterLevel, previousZoomLevel - 1, newZoomLevel);
+
+			//Need to add markers for those that weren't on the map before but are now
+			this._topClusterLevel._recursivelyAddChildrenToMap(null, newZoomLevel, this._getExpandedVisibleBounds());
+			//Remove markers that were on the map before but won't be now
+			this._topClusterLevel._recursivelyRemoveChildrenFromMap(this._currentShownBounds, previousZoomLevel, this._getExpandedVisibleBounds());
+		},
+		_animationAddLayer: function (layer, newCluster) {
+			var me = this,
+			    fg = this._featureGroup;
+
+			fg.addLayer(layer);
+			if (newCluster !== layer) {
+				if (newCluster._childCount > 2) { //Was already a cluster
+
+					newCluster._updateIcon();
+					this._forceLayout();
+					this._animationStart();
+
+					layer._setPos(this._map.latLngToLayerPoint(newCluster.getLatLng()));
+					layer.clusterHide();
+
+					this._enqueue(function () {
+						fg.removeLayer(layer);
+						layer.clusterShow();
+
+						me._animationEnd();
+					});
+
+				} else { //Just became a cluster
+					this._forceLayout();
+
+					me._animationStart();
+					me._animationZoomOutSingle(newCluster, this._map.getMaxZoom(), this._map.getZoom());
+				}
+			}
+		}
 	},
 
-	_animationZoomOut: function (previousZoomLevel, newZoomLevel) {
-		this._animationZoomOutSingle(this._topClusterLevel, previousZoomLevel - 1, newZoomLevel);
-
-		//Need to add markers for those that weren't on the map before but are now
-		this._topClusterLevel._recursivelyAddChildrenToMap(null, newZoomLevel, this._getExpandedVisibleBounds());
-		//Remove markers that were on the map before but won't be now
-		this._topClusterLevel._recursivelyRemoveChildrenFromMap(this._currentShownBounds, previousZoomLevel, this._getExpandedVisibleBounds());
-	},
+	// Private methods for animated versions.
 	_animationZoomOutSingle: function (cluster, previousZoomLevel, newZoomLevel) {
 		var bounds = this._getExpandedVisibleBounds();
 
@@ -1059,35 +1100,13 @@ L.MarkerClusterGroup.include(!L.DomUtil.TRANSITION ? {
 			me._animationEnd();
 		});
 	},
-	_animationAddLayer: function (layer, newCluster) {
-		var me = this,
-			fg = this._featureGroup;
 
-		fg.addLayer(layer);
-		if (newCluster !== layer) {
-			if (newCluster._childCount > 2) { //Was already a cluster
-
-				newCluster._updateIcon();
-				this._forceLayout();
-				this._animationStart();
-
-				layer._setPos(this._map.latLngToLayerPoint(newCluster.getLatLng()));
-				layer.clusterHide();
-
-				this._enqueue(function () {
-					fg.removeLayer(layer);
-					layer.clusterShow();
-
-					me._animationEnd();
-				});
-
-			} else { //Just became a cluster
-				this._forceLayout();
-
-				me._animationStart();
-				me._animationZoomOutSingle(newCluster, this._map.getMaxZoom(), this._map.getZoom());
-			}
+	_animationEnd: function () {
+		if (this._map) {
+			this._map._mapPane.className = this._map._mapPane.className.replace(' leaflet-cluster-anim', '');
 		}
+		this._inZoomAnimation--;
+		this.fire('animationend');
 	},
 
 	//Force a browser layout of stuff in the map


### PR DESCRIPTION
Following issues #382, #348 and PR #352, added a new option `animate` to `L.MarkerClusterGroup` to select the animation behaviour.

It defaults to `L.DomUtil.TRANSITION` so that if it is left unassigned, MCG keeps the current behaviour (it animates or not depending on `L.DomUtil.TRANSITION`) but it is determined at instantiation time instead of at script loading time.

This option affects zoomIn, zoomOut, addLayer, spiderfy and unspiderfy.

Also added a corresponding test spec and included it into spec/index.