### PR TITLE
Added animate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,10 @@ Enabled by default (boolean options):
 * **zoomToBoundsOnClick**: When you click a cluster we zoom to its bounds.
 * **spiderfyOnMaxZoom**: When you click a cluster at the bottom zoom level we spiderfy it so you can see all of its markers. (*Note: the spiderfy occurs at the current zoom level if all items within the cluster are physically located at the same latitude and longitude.*)
 * **removeOutsideVisibleBounds**: Clusters and markers too far from the viewport are removed from the map for performance.
+* **animate**: Smoothly split / merge cluster children when zooming and spiderfying. If `L.DomUtil.TRANSITION` is false, this option has no effect (no animation is possible).
 
 Other options
-* **animateAddingMarkers**: If set to true then adding individual markers to the MarkerClusterGroup after it has been added to the map will add the marker and animate it in to the cluster. Defaults to false as this gives better performance when bulk adding markers. addLayers does not support this, only addLayer with individual Markers.
+* **animateAddingMarkers**: If set to true (and `animate` option is also true) then adding individual markers to the MarkerClusterGroup after it has been added to the map will add the marker and animate it into the cluster. Defaults to false as this gives better performance when bulk adding markers. addLayers does not support this, only addLayer with individual Markers.
 * **disableClusteringAtZoom**: If set, at this zoom level and below markers will not be clustered. This defaults to disabled. [See Example](http://leaflet.github.com/Leaflet.markercluster/example/marker-clustering-realworld-maxzoom.388.html)
 * **maxClusterRadius**: The maximum radius that a cluster will cover from the central marker (in pixels). Default 80. Decreasing will make more, smaller clusters. You can also use a function that accepts the current map zoom and returns the maximum cluster radius in pixels.
 * **polygonOptions**: Options to pass when creating the L.Polygon(points, options) to show the bounds of a cluster

--- a/spec/index.html
+++ b/spec/index.html
@@ -36,6 +36,7 @@
 	<script type="text/javascript" src="suites/AddLayer.MultipleSpec.js"></script>
 	<script type="text/javascript" src="suites/AddLayer.SingleSpec.js"></script>
 	<script type="text/javascript" src="suites/AddLayersSpec.js"></script>
+	<script type="text/javascript" src="suites/animateOptionSpec.js"></script>
 
 	<script type="text/javascript" src="suites/ChildChangingIconSupportSpec.js"></script>
 

--- a/spec/suites/animateOptionSpec.js
+++ b/spec/suites/animateOptionSpec.js
@@ -1,0 +1,190 @@
+describe('animate option', function () {
+
+	/**
+	 * Wrapper for Mocha's `it` function, to avoid using `beforeEach` and `afterEach`
+	 * which create problems with PhantomJS when total number of tests (across all suites)
+	 * increases. Might be due to use of promises for which PhantomJS would performs badly?
+	 * NOTE: works only with synchronous code.
+	 * @param testDescription string
+	 * @param testInstructions function
+	 * @param testFinally function to be executed just before afterEach2, in the `finally` block.
+	 */
+	function it2(testDescription, testInstructions, testFinally) {
+
+		it(testDescription, function () {
+
+			// Before each test.
+			if (typeof beforeEach2 === "function") {
+				beforeEach2();
+			}
+
+			try {
+
+				// Perform the actual test instructions.
+				testInstructions();
+
+			} catch (e) {
+
+				// Re-throw the exception so that Mocha sees the failed test.
+				throw e;
+
+			} finally {
+
+				// If specific final instructions are provided.
+				if (typeof testFinally === "function") {
+					testFinally();
+				}
+
+				// After each test.
+				if (typeof afterEach2 === "function") {
+					afterEach2();
+				}
+
+			}
+		});
+	}
+
+
+	/////////////////////////////
+	// SETUP FOR EACH TEST
+	/////////////////////////////
+
+	/**
+	 * Instructions to be executed before each test called with `it2`.
+	 */
+	function beforeEach2() {
+
+		// Nothing for this test suite.
+
+	}
+
+	/**
+	 * Instructions to be executed after each test called with `it2`.
+	 */
+	function afterEach2() {
+
+		if (group instanceof L.MarkerClusterGroup) {
+			group.removeLayers(group.getLayers());
+			map.removeLayer(group);
+		}
+
+		// Throw away group as it can be assigned with different configurations between tests.
+		group = null;
+	}
+
+
+	/////////////////////////////
+	// PREPARATION CODE
+	/////////////////////////////
+
+	var div, map, group, previousTransitionSetting;
+
+	div = document.createElement('div');
+	div.style.width = '200px';
+	div.style.height = '200px';
+	document.body.appendChild(div);
+
+	map = L.map(div, { maxZoom: 18 });
+
+	// Corresponds to zoom level 8 for the above div dimensions.
+	map.fitBounds(new L.LatLngBounds([
+		[1, 1],
+		[2, 2]
+	]));
+
+
+	/////////////////////////////
+	// TESTS
+	/////////////////////////////
+
+	it2('hooks animated methods version by default', function () {
+
+		// Need to add to map so that we have the top cluster level created.
+		group = L.markerClusterGroup().addTo(map);
+
+		var withAnimation = L.MarkerClusterGroup.prototype._withAnimation;
+
+		// MCG animated methods.
+		expect(group._animationStart).to.be(withAnimation._animationStart);
+		expect(group._animationZoomIn).to.be(withAnimation._animationZoomIn);
+		expect(group._animationZoomOut).to.be(withAnimation._animationZoomOut);
+		expect(group._animationAddLayer).to.be(withAnimation._animationAddLayer);
+
+		// MarkerCluster spiderfy animated methods
+		var cluster = group._topClusterLevel;
+
+		withAnimation = L.MarkerCluster.prototype;
+
+		expect(cluster._animationSpiderfy).to.be(withAnimation._animationSpiderfy);
+		expect(cluster._animationUnspiderfy).to.be(withAnimation._animationUnspiderfy);
+
+	});
+
+	it2('hooks non-animated methods version when set to false', function () {
+
+		// Need to add to map so that we have the top cluster level created.
+		group = L.markerClusterGroup({animate: false}).addTo(map);
+
+		var noAnimation = L.MarkerClusterGroup.prototype._noAnimation;
+
+		// MCG non-animated methods.
+		expect(group._animationStart).to.be(noAnimation._animationStart);
+		expect(group._animationZoomIn).to.be(noAnimation._animationZoomIn);
+		expect(group._animationZoomOut).to.be(noAnimation._animationZoomOut);
+		expect(group._animationAddLayer).to.be(noAnimation._animationAddLayer);
+
+		// MarkerCluster spiderfy non-animated methods
+		var cluster = group._topClusterLevel;
+
+		noAnimation = L.MarkerClusterNonAnimated.prototype;
+
+		expect(cluster._animationSpiderfy).to.be(noAnimation._animationSpiderfy);
+		expect(cluster._animationUnspiderfy).to.be(noAnimation._animationUnspiderfy);
+
+	});
+
+	it2(
+		'always hooks non-animated methods version when L.DomUtil.TRANSITION is false',
+
+		function () {
+
+			previousTransitionSetting = L.DomUtil.TRANSITION;
+			// Fool Leaflet, make it think the browser does not support transitions.
+			L.DomUtil.TRANSITION = false;
+
+			// Need to add to map so that we have the top cluster level created.
+			group = L.markerClusterGroup({animate: true}).addTo(map);
+
+			var noAnimation = L.MarkerClusterGroup.prototype._noAnimation;
+
+			// MCG non-animated methods.
+			expect(group._animationStart).to.be(noAnimation._animationStart);
+			expect(group._animationZoomIn).to.be(noAnimation._animationZoomIn);
+			expect(group._animationZoomOut).to.be(noAnimation._animationZoomOut);
+			expect(group._animationAddLayer).to.be(noAnimation._animationAddLayer);
+
+			// MarkerCluster spiderfy non-animated methods
+			var cluster = group._topClusterLevel;
+
+			noAnimation = L.MarkerClusterNonAnimated.prototype;
+
+			expect(cluster._animationSpiderfy).to.be(noAnimation._animationSpiderfy);
+			expect(cluster._animationUnspiderfy).to.be(noAnimation._animationUnspiderfy);
+
+		},
+
+		function () {
+			// Restore previous setting so that next tests are unaffected.
+			L.DomUtil.TRANSITION = previousTransitionSetting;
+		}
+	);
+
+
+	/////////////////////////////
+	// CLEAN UP CODE
+	/////////////////////////////
+
+	map.remove();
+	document.body.removeChild(div);
+
+});

--- a/src/MarkerCluster.Spiderfier.js
+++ b/src/MarkerCluster.Spiderfier.js
@@ -116,7 +116,7 @@ L.MarkerCluster.include({
 	}
 });
 
-L.MarkerCluster.include(!L.DomUtil.TRANSITION ? {
+L.MarkerClusterNonAnimated = L.MarkerCluster.extend({
 	//Non Animated versions of everything
 	_animationSpiderfy: function (childMarkers, positions) {
 		var group = this._group,
@@ -148,7 +148,9 @@ L.MarkerCluster.include(!L.DomUtil.TRANSITION ? {
 	_animationUnspiderfy: function () {
 		this._noanimationUnspiderfy();
 	}
-} : {
+});
+
+L.MarkerCluster.include({
 	//Animated versions here
 	SVG_ANIMATION: (function () {
 		return document.createElementNS('http://www.w3.org/2000/svg', 'animate').toString().indexOf('SVGAnimate') > -1;


### PR DESCRIPTION
Deleted previous branch animationOption since I messed up trying to rebase...
This closed PR #576.

Following issues #382, #348 and PR #352, added a new option `animate` to `L.MarkerClusterGroup` to select the animation behaviour. This option affects zoomIn, zoomOut, addLayer, spiderfy and unspiderfy.

It defaults to true and its effect is ignored if `L.DomUtil.TRANSITION` is false, so that MCG keeps the current behaviour (it animates or not depending on `L.DomUtil.TRANSITION`) when this option is left unassigned.

The only difference is that its effect is determined at instantiation time instead of at script loading time.

To achieve this, this code removes the test condition when including the animation (or non-animation) methods. It adds all methods to prototype, and hooks to the appropriate one at initialization.

`L.MarkerCluster` is also adapted, because it animates when spiderfying. In order to avoid having to hook at each instantiation, this code actually creates an extended class `L.MarkerClusterNonAnimated` which includes the non-animated methods. Then `L.MarkerClusterGroup` instantiates the appropriate class.

Also created a dedicated test spec and included it into spec/index.

Finally updated README to describe this new option and its effect on `animateAddingMarkers` option.