### PR TITLE
Made refreshClusters to re-draw markers in singleMarkerMode

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -37,6 +37,7 @@
 	<script type="text/javascript" src="suites/AddLayer.SingleSpec.js"></script>
 	<script type="text/javascript" src="suites/AddLayersSpec.js"></script>
 	<script type="text/javascript" src="suites/animateOptionSpec.js"></script>
+	<script type="text/javascript" src="suites/singleMarkerModeSpec.js"></script>
 
 	<script type="text/javascript" src="suites/ChildChangingIconSupportSpec.js"></script>
 

--- a/spec/suites/RefreshSpec.js
+++ b/spec/suites/RefreshSpec.js
@@ -1,58 +1,24 @@
 ﻿describe('refreshClusters', function () {
 
 	/**
-	 * Wrapper for Mocha's `it` function, to avoid using `beforeEach` and `afterEach`
-	 * which create problems with PhantomJS when total number of tests (across all suites)
-	 * increases. Might be due to use of promises for which PhantomJS would perform badly?
-	 * NOTE: works only with synchronous code.
-	 * @param testDescription string
-	 * @param testInstructions function
-	 * @param testFinally function to be executed just before afterEach2, in the `finally` block.
+	 * Avoid as much as possible creating and destroying objects for each test.
+	 * Instead, try re-using them, except for the ones under test of course.
+	 * PhantomJS does not perform garbage collection for the life of the page,
+	 * i.e. during the entire test process (Karma runs all tests in a single page).
+	 * http://stackoverflow.com/questions/27239708/how-to-get-around-memory-error-with-karma-phantomjs
+	 *
+	 * The `beforeEach` and `afterEach do not seem to cause much issue.
+	 * => they can still be used to initialize some setup between each test.
+	 * Using them keeps a readable spec/index.
+	 *
+	 * But refrain from re-creating div and map every time. Re-use those objects.
 	 */
-	function it2(testDescription, testInstructions, testFinally) {
-
-		it(testDescription, function () {
-
-			// Before each test.
-			if (typeof beforeEach2 === "function") {
-				beforeEach2();
-			}
-
-			try {
-
-				// Perform the actual test instructions.
-				testInstructions();
-
-			} catch (e) {
-
-				// Re-throw the exception so that Mocha sees the failed test.
-				throw e;
-
-			} finally {
-
-				// If specific final instructions are provided.
-				if (typeof testFinally === "function") {
-					testFinally();
-				}
-
-				// After each test.
-				if (typeof afterEach2 === "function") {
-					afterEach2();
-				}
-
-			}
-		});
-	}
-
 
 	/////////////////////////////
 	// SETUP FOR EACH TEST
 	/////////////////////////////
 
-	/**
-	 * Instructions to be executed before each test called with `it2`.
-	 */
-	function beforeEach2() {
+	beforeEach(function () {
 
 		clock = sinon.useFakeTimers();
 
@@ -64,12 +30,9 @@
 			[-10, -10]
 		]))
 
-	}
+	});
 
-	/**
-	 * Instructions to be executed after each test called with `it2`.
-	 */
-	function afterEach2() {
+	afterEach(function () {
 
 		if (group instanceof L.MarkerClusterGroup) {
 			group.removeLayers(group.getLayers());
@@ -82,12 +45,14 @@
 
 		clock.restore();
 		clock = null;
-	}
+
+	});
 
 
 	/////////////////////////////
 	// PREPARATION CODE
 	/////////////////////////////
+
 
 	var div, map, group, clock;
 
@@ -128,7 +93,7 @@
 	// TESTS
 	/////////////////////////////
 
-	it2('flags all non-visible parent clusters of a given marker', function () {
+	it('flags all non-visible parent clusters of a given marker', function () {
 
 		group = L.markerClusterGroup().addTo(map);
 
@@ -171,7 +136,7 @@
 
 	});
 
-	it2('re-draws visible clusters', function () {
+	it('re-draws visible clusters', function () {
 
 		group = L.markerClusterGroup({
 			iconCreateFunction: function (cluster) {
@@ -220,7 +185,7 @@
 
 	});
 
-	it2('re-draws markers in singleMarkerMode', function () {
+	it('re-draws markers in singleMarkerMode', function () {
 
 		group = L.markerClusterGroup({
 			singleMarkerMode: true,
@@ -334,7 +299,7 @@
 		// Ready to refresh clusters with method of choice and assess result.
 	}
 
-	it2('does not flag clusters of other markers', function () {
+	it('does not flag clusters of other markers', function () {
 
 		init3clusterBranches();
 
@@ -355,7 +320,7 @@
 
 	});
 
-	it2('processes itself when no argument is passed', function () {
+	it('processes itself when no argument is passed', function () {
 
 		init3clusterBranches();
 
@@ -375,7 +340,7 @@
 
 	});
 
-	it2('accepts an array of markers', function () {
+	it('accepts an array of markers', function () {
 
 		init3clusterBranches();
 
@@ -397,7 +362,7 @@
 
 	});
 
-	it2('accepts a mapping of markers', function () {
+	it('accepts a mapping of markers', function () {
 
 		init3clusterBranches();
 
@@ -421,7 +386,7 @@
 
 	});
 
-	it2('accepts an L.LayerGroup', function () {
+	it('accepts an L.LayerGroup', function () {
 
 		init3clusterBranches();
 
@@ -444,7 +409,7 @@
 
 	});
 
-	it2('accepts an L.MarkerCluster', function () {
+	it('accepts an L.MarkerCluster', function () {
 
 		init3clusterBranches();
 

--- a/spec/suites/singleMarkerModeSpec.js
+++ b/spec/suites/singleMarkerModeSpec.js
@@ -1,0 +1,146 @@
+describe('singleMarkerMode option', function () {
+
+	/**
+	 * Wrapper for Mocha's `it` function, to avoid using `beforeEach` and `afterEach`
+	 * which create problems with PhantomJS when total number of tests (across all suites)
+	 * increases. Might be due to use of promises for which PhantomJS would perform badly?
+	 * NOTE: works only with synchronous code.
+	 * @param testDescription string
+	 * @param testInstructions function
+	 * @param testFinally function to be executed just before afterEach2, in the `finally` block.
+	 */
+	function it2(testDescription, testInstructions, testFinally) {
+
+		it(testDescription, function () {
+
+			// Before each test.
+			if (typeof beforeEach2 === "function") {
+				beforeEach2();
+			}
+
+			try {
+
+				// Perform the actual test instructions.
+				testInstructions();
+
+			} catch (e) {
+
+				// Re-throw the exception so that Mocha sees the failed test.
+				throw e;
+
+			} finally {
+
+				// If specific final instructions are provided.
+				if (typeof testFinally === "function") {
+					testFinally();
+				}
+
+				// After each test.
+				if (typeof afterEach2 === "function") {
+					afterEach2();
+				}
+
+			}
+		});
+	}
+
+
+	/////////////////////////////
+	// SETUP FOR EACH TEST
+	/////////////////////////////
+
+	/**
+	 * Instructions to be executed before each test called with `it2`.
+	 */
+	function beforeEach2() {
+
+		// Reset the marker icon.
+		marker.setIcon(defaultIcon);
+
+	}
+
+	/**
+	 * Instructions to be executed after each test called with `it2`.
+	 */
+	function afterEach2() {
+
+		if (group instanceof L.MarkerClusterGroup) {
+			group.removeLayers(group.getLayers());
+			map.removeLayer(group);
+		}
+
+		// Throw away group as it can be assigned with different configurations between tests.
+		group = null;
+	}
+
+
+	/////////////////////////////
+	// PREPARATION CODE
+	/////////////////////////////
+
+	var div, map, group;
+
+	var defaultIcon = new L.Icon.Default(),
+	    clusterIcon = new L.Icon.Default(),
+		marker = L.marker([1.5, 1.5]);
+
+	div = document.createElement('div');
+	div.style.width = '200px';
+	div.style.height = '200px';
+	document.body.appendChild(div);
+
+	map = L.map(div, { maxZoom: 18 });
+
+	// Corresponds to zoom level 8 for the above div dimensions.
+	map.fitBounds(new L.LatLngBounds([
+		[1, 1],
+		[2, 2]
+	]));
+
+
+	/////////////////////////////
+	// TESTS
+	/////////////////////////////
+
+	it2('overrides marker icons when set to true', function () {
+
+		group = L.markerClusterGroup({
+			singleMarkerMode: true,
+			iconCreateFunction: function (layer) {
+				return clusterIcon;
+			}
+		}).addTo(map);
+
+		expect(marker.options.icon).to.equal(defaultIcon);
+
+		marker.addTo(group);
+
+		expect(marker.options.icon).to.equal(clusterIcon);
+
+	});
+
+	it2('does not modify marker icons by default (or set to false)', function () {
+
+		group = L.markerClusterGroup({
+			iconCreateFunction: function (layer) {
+				return clusterIcon;
+			}
+		}).addTo(map);
+
+		expect(marker.options.icon).to.equal(defaultIcon);
+
+		marker.addTo(group);
+
+		expect(marker.options.icon).to.equal(defaultIcon);
+
+	});
+
+
+	/////////////////////////////
+	// CLEAN UP CODE
+	/////////////////////////////
+
+	map.remove();
+	document.body.removeChild(div);
+
+});

--- a/spec/suites/singleMarkerModeSpec.js
+++ b/spec/suites/singleMarkerModeSpec.js
@@ -1,68 +1,31 @@
 describe('singleMarkerMode option', function () {
 
 	/**
-	 * Wrapper for Mocha's `it` function, to avoid using `beforeEach` and `afterEach`
-	 * which create problems with PhantomJS when total number of tests (across all suites)
-	 * increases. Might be due to use of promises for which PhantomJS would perform badly?
-	 * NOTE: works only with synchronous code.
-	 * @param testDescription string
-	 * @param testInstructions function
-	 * @param testFinally function to be executed just before afterEach2, in the `finally` block.
+	 * Avoid as much as possible creating and destroying objects for each test.
+	 * Instead, try re-using them, except for the ones under test of course.
+	 * PhantomJS does not perform garbage collection for the life of the page,
+	 * i.e. during the entire test process (Karma runs all tests in a single page).
+	 * http://stackoverflow.com/questions/27239708/how-to-get-around-memory-error-with-karma-phantomjs
+	 *
+	 * The `beforeEach` and `afterEach do not seem to cause much issue.
+	 * => they can still be used to initialize some setup between each test.
+	 * Using them keeps a readable spec/index.
+	 *
+	 * But refrain from re-creating div and map every time. Re-use those objects.
 	 */
-	function it2(testDescription, testInstructions, testFinally) {
-
-		it(testDescription, function () {
-
-			// Before each test.
-			if (typeof beforeEach2 === "function") {
-				beforeEach2();
-			}
-
-			try {
-
-				// Perform the actual test instructions.
-				testInstructions();
-
-			} catch (e) {
-
-				// Re-throw the exception so that Mocha sees the failed test.
-				throw e;
-
-			} finally {
-
-				// If specific final instructions are provided.
-				if (typeof testFinally === "function") {
-					testFinally();
-				}
-
-				// After each test.
-				if (typeof afterEach2 === "function") {
-					afterEach2();
-				}
-
-			}
-		});
-	}
-
 
 	/////////////////////////////
 	// SETUP FOR EACH TEST
 	/////////////////////////////
 
-	/**
-	 * Instructions to be executed before each test called with `it2`.
-	 */
-	function beforeEach2() {
+	beforeEach(function () {
 
 		// Reset the marker icon.
 		marker.setIcon(defaultIcon);
 
-	}
+	});
 
-	/**
-	 * Instructions to be executed after each test called with `it2`.
-	 */
-	function afterEach2() {
+	afterEach(function () {
 
 		if (group instanceof L.MarkerClusterGroup) {
 			group.removeLayers(group.getLayers());
@@ -71,7 +34,8 @@ describe('singleMarkerMode option', function () {
 
 		// Throw away group as it can be assigned with different configurations between tests.
 		group = null;
-	}
+
+	});
 
 
 	/////////////////////////////
@@ -102,7 +66,7 @@ describe('singleMarkerMode option', function () {
 	// TESTS
 	/////////////////////////////
 
-	it2('overrides marker icons when set to true', function () {
+	it('overrides marker icons when set to true', function () {
 
 		group = L.markerClusterGroup({
 			singleMarkerMode: true,
@@ -119,7 +83,7 @@ describe('singleMarkerMode option', function () {
 
 	});
 
-	it2('does not modify marker icons by default (or set to false)', function () {
+	it('does not modify marker icons by default (or set to false)', function () {
 
 		group = L.markerClusterGroup({
 			iconCreateFunction: function (layer) {

--- a/src/MarkerClusterGroup.Refresh.js
+++ b/src/MarkerClusterGroup.Refresh.js
@@ -85,8 +85,12 @@ L.MarkerClusterGroup.include({
 
 		for (id in layers) {
 			layer = layers[id];
-			// Need to re-create the icon first, then re-draw the marker.
-			layer.setIcon(this._overrideMarkerIcon(layer));
+
+			// Make sure we do not override markers that do not belong to THIS group.
+			if (this.hasLayer(layer)) {
+				// Need to re-create the icon first, then re-draw the marker.
+				layer.setIcon(this._overrideMarkerIcon(layer));
+			}
 		}
 	}
 });

--- a/src/MarkerClusterGroup.Refresh.js
+++ b/src/MarkerClusterGroup.Refresh.js
@@ -8,7 +8,8 @@
 
 L.MarkerClusterGroup.include({
 	/**
-	 * Updates all clusters (and their icon) which are parents of the given marker(s).
+	 * Updates the icon of all clusters which are parents of the given marker(s).
+	 * In singleMarkerMode, also updates the given marker(s) icon.
 	 * @param layers L.MarkerClusterGroup|L.LayerGroup|Array(L.Marker)|Map(L.Marker)|
 	 * L.MarkerCluster|L.Marker (optional) list of markers (or single marker) whose parent
 	 * clusters need to be updated. If not provided, retrieves all child markers of this.
@@ -29,6 +30,11 @@ L.MarkerClusterGroup.include({
 		this._flagParentsIconsNeedUpdate(layers);
 		this._refreshClustersIcons();
 
+		// In case of singleMarkerMode, also re-draw the markers.
+		if (this.options.singleMarkerMode) {
+			this._refreshSingleMarkerModeMarkers(layers);
+		}
+
 		return this;
 	},
 
@@ -38,7 +44,7 @@ L.MarkerClusterGroup.include({
 	 * @private
 	 */
 	_flagParentsIconsNeedUpdate: function (layers) {
-		var parent, id;
+		var id, parent;
 
 		// Assumes layers is an Array or an Object whose prototype is non-enumerable.
 		for (id in layers) {
@@ -51,17 +57,6 @@ L.MarkerClusterGroup.include({
 			while (parent) {
 				parent._iconNeedsUpdate = true;
 				parent = parent.__parent;
-			}
-		}
-
-		// In case of singleMarkerMode, also re-draw the markers.
-		if (this.options.singleMarkerMode) {
-			var layer;
-
-			for (id in layers) {
-				layer = layers[id];
-				// Need to re-create the icon first, then re-draw the marker.
-				layer.setIcon(this._overrideMarkerIcon(layer));
 			}
 		}
 	},
@@ -77,6 +72,22 @@ L.MarkerClusterGroup.include({
 				c._updateIcon();
 			}
 		});
+	},
+
+	/**
+	 * Re-draws the icon of the supplied markers.
+	 * To be used in singleMarkerMode only.
+	 * @param layers Array(L.Marker)|Map(L.Marker) list of markers.
+	 * @private
+	 */
+	_refreshSingleMarkerModeMarkers: function (layers) {
+		var id, layer;
+
+		for (id in layers) {
+			layer = layers[id];
+			// Need to re-create the icon first, then re-draw the marker.
+			layer.setIcon(this._overrideMarkerIcon(layer));
+		}
 	}
 });
 

--- a/src/MarkerClusterGroup.Refresh.js
+++ b/src/MarkerClusterGroup.Refresh.js
@@ -38,10 +38,10 @@ L.MarkerClusterGroup.include({
 	 * @private
 	 */
 	_flagParentsIconsNeedUpdate: function (layers) {
-		var parent;
+		var parent, id;
 
 		// Assumes layers is an Array or an Object whose prototype is non-enumerable.
-		for (var id in layers) {
+		for (id in layers) {
 			// Flag parent clusters' icon as "dirty", all the way up.
 			// Dumb process that flags multiple times upper parents, but still
 			// much more efficient than trying to be smart and make short lists,
@@ -51,6 +51,17 @@ L.MarkerClusterGroup.include({
 			while (parent) {
 				parent._iconNeedsUpdate = true;
 				parent = parent.__parent;
+			}
+		}
+
+		// In case of singleMarkerMode, also re-draw the markers.
+		if (this.options.singleMarkerMode) {
+			var layer;
+
+			for (id in layers) {
+				layer = layers[id];
+				// Need to re-create the icon first, then re-draw the marker.
+				layer.setIcon(this._overrideMarkerIcon(layer));
 			}
 		}
 	},

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -796,14 +796,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		    markerPoint, z;
 
 		if (this.options.singleMarkerMode) {
-			layer.options.icon = this.options.iconCreateFunction({
-				getChildCount: function () {
-					return 1;
-				},
-				getAllChildMarkers: function () {
-					return [layer];
-				}
-			});
+			this._overrideMarkerIcon(layer);
 		}
 
 		//Find the lowest zoom level to slot this one in
@@ -923,6 +916,25 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		} else {
 			newCluster._updateIcon();
 		}
+	},
+
+	/**
+	 * Implements the singleMarkerMode option.
+	 * @param layer Marker to re-style using the Clusters iconCreateFunction.
+	 * @returns {L.Icon} The newly created icon.
+	 * @private
+	 */
+	_overrideMarkerIcon: function (layer) {
+		var icon = layer.options.icon = this.options.iconCreateFunction({
+			getChildCount: function () {
+				return 1;
+			},
+			getAllChildMarkers: function () {
+				return [layer];
+			}
+		});
+
+		return icon;
 	}
 });
 


### PR DESCRIPTION
Following issue #581, improved `refreshClusters()` method so that it detects `singleMarkerMode` and re-draws all passed markers as well, not only parent clusters. Took the opportunity to factorize code with `_addLayer()` method, creating a new `_overrideMarkerIcon()` method that re-styles the marker using the `iconCreateFunction` from clusters.

Added an extra test in RefreshSpec test suite to cover this case. Also re-factored it using `it2` wrapper to avoid hanging test process.

Also created the singleMarkerModeSpec test suite to test `singleMarkerMode` option and included it into the new suite into spec/index.