### PR TITLE
Optimized performance of bulk addLayers and removeLayers

### DIFF
--- a/src/MarkerCluster.js
+++ b/src/MarkerCluster.js
@@ -11,6 +11,7 @@ L.MarkerCluster = L.Marker.extend({
 		this._childClusters = [];
 		this._childCount = 0;
 		this._iconNeedsUpdate = true;
+		this._boundsNeedUpdate = true;
 
 		this._bounds = new L.LatLngBounds();
 
@@ -99,7 +100,9 @@ L.MarkerCluster = L.Marker.extend({
 	_addChild: function (new1, isNotificationFromChild) {
 
 		this._iconNeedsUpdate = true;
-		this._expandBounds(new1);
+
+		this._boundsNeedUpdate = true;
+		this._setClusterCenter(new1);
 
 		if (new1 instanceof L.MarkerCluster) {
 			if (!isNotificationFromChild) {
@@ -119,34 +122,65 @@ L.MarkerCluster = L.Marker.extend({
 		}
 	},
 
-	//Expand our bounds and tell our parent to
-	_expandBounds: function (marker) {
-		var addedCount,
-		    addedLatLng = marker._wLatLng || marker._latlng;
-
-		if (marker instanceof L.MarkerCluster) {
-			this._bounds.extend(marker._bounds);
-			addedCount = marker._childCount;
-		} else {
-			this._bounds.extend(addedLatLng);
-			addedCount = 1;
-		}
-
+	/**
+	 * Makes sure the cluster center is set. If not, uses the child center if it is a cluster, or the marker position.
+	 * @param child L.MarkerCluster|L.Marker that will be used as cluster center if not defined yet.
+	 * @private
+	 */
+	_setClusterCenter: function (child) {
 		if (!this._cLatLng) {
 			// when clustering, take position of the first point as the cluster center
-			this._cLatLng = marker._cLatLng || addedLatLng;
+			this._cLatLng = child._cLatLng || child._latlng;
+		}
+	},
+
+	_recalculateBounds: function () {
+		var markers = this._markers,
+		    childClusters = this._childClusters,
+		    latSum = 0,
+		    lngSum = 0,
+		    totalCount = this._childCount,
+		    i, child, childLatLng, childCount;
+
+		this._bounds = new L.LatLngBounds();
+
+		// Case where all markers are removed from the map and we are left with just an empty _topClusterLevel.
+		if (totalCount === 0) {
+			return;
 		}
 
-		// when showing clusters, take weighted average of all points as cluster center
-		var totalCount = this._childCount + addedCount;
+		// Child markers.
+		for (i = 0; i < markers.length; i++) {
+			childLatLng = markers[i]._latlng;
 
-		//Calculate weighted latlng for display
-		if (!this._wLatLng) {
-			this._latlng = this._wLatLng = new L.LatLng(addedLatLng.lat, addedLatLng.lng);
-		} else {
-			this._wLatLng.lat = (addedLatLng.lat * addedCount + this._wLatLng.lat * this._childCount) / totalCount;
-			this._wLatLng.lng = (addedLatLng.lng * addedCount + this._wLatLng.lng * this._childCount) / totalCount;
+			this._bounds.extend(childLatLng);
+
+			latSum += childLatLng.lat;
+			lngSum += childLatLng.lng;
 		}
+
+		// Child clusters.
+		for (i = 0; i < childClusters.length; i++) {
+			child = childClusters[i];
+
+			// Re-compute child bounds and weighted position first if necessary.
+			if (child._boundsNeedUpdate) {
+				child._recalculateBounds();
+			}
+
+			this._bounds.extend(child._bounds);
+
+			childLatLng = child._wLatLng;
+			childCount = child._childCount;
+
+			latSum += childLatLng.lat * childCount;
+			lngSum += childLatLng.lng * childCount;
+		}
+
+		this._latlng = this._wLatLng = new L.LatLng(latSum / totalCount, lngSum / totalCount);
+
+		// Reset dirty flag.
+		this._boundsNeedUpdate = false;
 	},
 
 	//Set our markers position as given and add it to the map
@@ -344,20 +378,20 @@ L.MarkerCluster = L.Marker.extend({
 		}
 	},
 
-	_recalculateBounds: function () {
-		var markers = this._markers,
-			childClusters = this._childClusters,
-			i;
+	/**
+	 * Runs a function recursively on every child cluster, then on THIS cluster.
+	 * @param runAtEveryLevel function to be called on each cluster. Takes as single argument the cluster to be processed.
+	 * @private
+	 */
+	_recursivelySimple: function (runAtEveryLevel) {
+		var childClusters = this._childClusters,
+		    i = 0;
 
-		this._bounds = new L.LatLngBounds();
-		delete this._wLatLng;
+		for (; i < childClusters.length; i++) {
+			childClusters[i]._recursivelySimple(runAtEveryLevel);
+		}
 
-		for (i = markers.length - 1; i >= 0; i--) {
-			this._expandBounds(markers[i]);
-		}
-		for (i = childClusters.length - 1; i >= 0; i--) {
-			this._expandBounds(childClusters[i]);
-		}
+		return runAtEveryLevel(this);
 	},
 
 

--- a/src/MarkerCluster.js
+++ b/src/MarkerCluster.js
@@ -404,18 +404,3 @@ L.MarkerCluster = L.Marker.extend({
 		return this._childClusters.length > 0 && this._childClusters[0]._childCount === this._childCount;
 	}
 });
-
-/**
- * Assigns impossible bounding values so that the next extend entirely determines the new bounds.
- * This method avoids having to trash the previous object and to create a new one, which is much slower for this class.
- */
-L.LatLngBounds.prototype.reset = function () {
-	if (this._southWest) {
-		this._southWest.lat = Infinity;
-		this._southWest.lng = Infinity;
-	}
-	if (this._northEast) {
-		this._northEast.lat = -Infinity;
-		this._northEast.lng = -Infinity;
-	}
-};

--- a/src/MarkerCluster.js
+++ b/src/MarkerCluster.js
@@ -134,6 +134,25 @@ L.MarkerCluster = L.Marker.extend({
 		}
 	},
 
+	/**
+	 * Assigns impossible bounding values so that the next extend entirely determines the new bounds.
+	 * This method avoids having to trash the previous L.LatLngBounds object and to create a new one, which is much slower for this class.
+	 * As long as the bounds are not extended, most other methods would probably fail, as they would with bounds initialized but not extended.
+	 * @private
+	 */
+	_resetBounds: function () {
+		var bounds = this._bounds;
+
+		if (bounds._southWest) {
+			bounds._southWest.lat = Infinity;
+			bounds._southWest.lng = Infinity;
+		}
+		if (bounds._northEast) {
+			bounds._northEast.lat = -Infinity;
+			bounds._northEast.lng = -Infinity;
+		}
+	},
+
 	_recalculateBounds: function () {
 		var markers = this._markers,
 		    childClusters = this._childClusters,
@@ -148,7 +167,7 @@ L.MarkerCluster = L.Marker.extend({
 		}
 
 		// Reset rather than creating a new object, for performance.
-		this._bounds.reset();
+		this._resetBounds();
 
 		// Child markers.
 		for (i = 0; i < markers.length; i++) {

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -105,7 +105,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 
 		this._addLayer(layer, this._maxZoom);
 
-		// Re-calculate bounds must be done manually now.
+		// Refresh bounds and weighted positions.
 		this._topClusterLevel._recalculateBounds();
 
 		//Work out what is visible
@@ -163,7 +163,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		//Remove the marker from clusters
 		this._removeLayer(layer, true);
 
-		// Bounds and weighted position must be done manually now.
+		// Refresh bounds and weighted positions.
 		this._topClusterLevel._recalculateBounds();
 
 		if (this._featureGroup.hasLayer(layer)) {
@@ -314,7 +314,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 			}
 		}
 
-		// Re-compute bounds and weighted positions.
+		// Refresh bounds and weighted positions.
 		this._topClusterLevel._recalculateBounds();
 
 		//Fix up the clusters and markers on the map
@@ -526,9 +526,6 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		l = this._needsClustering;
 		this._needsClustering = [];
 		this.addLayers(l);
-
-		// Re-compute bounds and weighted positions.
-		this._topClusterLevel._recalculateBounds();
 	},
 
 	//Overrides FeatureGroup.onRemove
@@ -641,7 +638,6 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 					}
 				}
 			} else {
-				//cluster._recalculateBounds();
 				if (!dontUpdateMap || !cluster._icon) {
 					cluster._updateIcon();
 				}

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -105,6 +105,9 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 
 		this._addLayer(layer, this._maxZoom);
 
+		// Re-calculate bounds must be done manually now.
+		this._topClusterLevel._recalculateBounds();
+
 		//Work out what is visible
 		var visibleLayer = layer,
 			currentZoom = this._map.getZoom();
@@ -159,6 +162,9 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 
 		//Remove the marker from clusters
 		this._removeLayer(layer, true);
+
+		// Bounds and weighted position must be done manually now.
+		this._topClusterLevel._recalculateBounds();
 
 		if (this._featureGroup.hasLayer(layer)) {
 			this._featureGroup.removeLayer(layer);
@@ -222,7 +228,12 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 					chunkProgress(offset, layersArray.length, (new Date()).getTime() - started);
 				}
 
+				// Completed processing all markers.
 				if (offset === layersArray.length) {
+
+					// Refresh bounds and weighted positions.
+					this._topClusterLevel._recalculateBounds();
+
 					//Update the icons of all those visible clusters that were affected
 					this._featureGroup.eachLayer(function (c) {
 						if (c instanceof L.MarkerCluster && c._iconNeedsUpdate) {
@@ -302,6 +313,9 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 				}
 			}
 		}
+
+		// Re-compute bounds and weighted positions.
+		this._topClusterLevel._recalculateBounds();
 
 		//Fix up the clusters and markers on the map
 		this._topClusterLevel._recursivelyAddChildrenToMap(null, this._zoom, this._currentShownBounds);
@@ -512,6 +526,9 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		l = this._needsClustering;
 		this._needsClustering = [];
 		this.addLayers(l);
+
+		// Re-compute bounds and weighted positions.
+		this._topClusterLevel._recalculateBounds();
 	},
 
 	//Overrides FeatureGroup.onRemove
@@ -558,6 +575,23 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		}
 	},
 
+	/**
+	 * Removes a marker from all _gridUnclustered zoom levels, starting at the supplied zoom.
+	 * @param marker to be removed from _gridUnclustered.
+	 * @param z integer bottom start zoom level (included)
+	 * @private
+	 */
+	_removeFromGridUnclustered: function (marker, z) {
+		var map = this._map,
+		    gridUnclustered = this._gridUnclustered;
+
+		for (; z >= 0; z--) {
+			if (!gridUnclustered[z].removeObject(marker, map.project(marker.getLatLng(), z))) {
+				break;
+			}
+		}
+	},
+
 	//Internal function for removing a marker from everything.
 	//dontUpdateMap: set to true if you will handle updating the map manually (for bulk functions)
 	_removeLayer: function (marker, removeFromDistanceGrid, dontUpdateMap) {
@@ -568,11 +602,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 
 		//Remove the marker from distance clusters it might be in
 		if (removeFromDistanceGrid) {
-			for (var z = this._maxZoom; z >= 0; z--) {
-				if (!gridUnclustered[z].removeObject(marker, map.project(marker.getLatLng(), z))) {
-					break;
-				}
-			}
+			this._removeFromGridUnclustered(marker, this._maxZoom);
 		}
 
 		//Work our way up the clusters removing them as we go if required
@@ -585,6 +615,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 
 		while (cluster) {
 			cluster._childCount--;
+			cluster._boundsNeedUpdate = true;
 
 			if (cluster._zoom < 0) {
 				//Top level, do nothing
@@ -610,7 +641,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 					}
 				}
 			} else {
-				cluster._recalculateBounds();
+				//cluster._recalculateBounds();
 				if (!dontUpdateMap || !cluster._icon) {
 					cluster._updateIcon();
 				}
@@ -842,11 +873,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 				parent._addChild(lastParent);
 
 				//Remove closest from this zoom level and any above that it is in, replace with newCluster
-				for (z = zoom; z >= 0; z--) {
-					if (!gridUnclustered[z].removeObject(closest, this._map.project(closest.getLatLng(), z))) {
-						break;
-					}
-				}
+				this._removeFromGridUnclustered(closest, zoom);
 
 				return;
 			}


### PR DESCRIPTION
Following the super interesting thread in #536, I succeeded in implementing the 3 optimizations:
- No bounds and weighted position computation during adding.
- No complete bounds and weighted position re-computation during remove.
- Reset LatLngBounds rather than re-create objects.

This was easier than I originally thought, and the patch is quite elegant I find: it flags clusters as having "dirty" bounds and position (using `_boundsNeedUpdate` new flag), in the same manner as `_iconNeedsUpdate`, so that at the end of the add / remove, we can call `this._topClusterLevel._recalculateBounds()` only once and refresh only clusters that need to be.

The performance gain is very substantial: about 5x for `addLayers` and 10x for `removeLayers`!
With the realworld.50000 example (without `chunkedLoading`), in seconds:

 Version | Firefox | Chrome
------ | :----: | :----:
addLayers master | 3.9 | 1.3
addLayers optimized | 0.7 | 0.4
removeLayers master | 8.0 | 3.0
removeLayers optimized | 0.3 | 0.3

![mcg_addlayers_optimization](https://cloud.githubusercontent.com/assets/12232803/10608765/7d458314-7751-11e5-8c05-f4639b89661d.png)

The fact that `removeLayers` was taking twice as long as `addLayers`, besides being counter-intuitive, highlights the problem of still recalculating all parent clusters bounds and position completely for every removed marker.

Thanks a lot to @OriginalSin for having pointed out the directions for improvement. I tried previously on my own but miserably failed.