### PR TITLE
Replaced spiderfy legs animation from SMIL to CSS transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ By default the Clusterer enables some nice defaults for you:
 * **zoomToBoundsOnClick**: When you click a cluster we zoom to its bounds.
 * **spiderfyOnMaxZoom**: When you click a cluster at the bottom zoom level we spiderfy it so you can see all of its markers. (*Note: the spiderfy occurs at the current zoom level if all items within the cluster are physically located at the same latitude and longitude.*)
 * **removeOutsideVisibleBounds**: Clusters and markers too far from the viewport are removed from the map for performance.
-* **spiderLegPolylineOptions**: Allows you to specify [PolylineOptions](http://leafletjs.com/reference.html#polyline-options) to style spider legs. By default, they are `{ weight: 1.5, color: '#222' }`.
+* **spiderLegPolylineOptions**: Allows you to specify [PolylineOptions](http://leafletjs.com/reference.html#polyline-options) to style spider legs. By default, they are `{ weight: 1.5, color: '#222', opacity: 0.5 }`.
 
 You can disable any of these as you want in the options when you create the MarkerClusterGroup:
 ```javascript
@@ -78,7 +78,7 @@ If you need to update the clusters icon (e.g. they are based on markers real-tim
 * **maxClusterRadius**: The maximum radius that a cluster will cover from the central marker (in pixels). Default 80. Decreasing will make more, smaller clusters. You can also use a function that accepts the current map zoom and returns the maximum cluster radius in pixels.
 * **polygonOptions**: Options to pass when creating the L.Polygon(points, options) to show the bounds of a cluster. Defaults to empty, which lets Leaflet use the [default Path options](http://leafletjs.com/reference.html#path-options).
 * **singleMarkerMode**: If set to true, overrides the icon for all added markers to make them appear as a 1 size cluster. Note: the markers are not replaced by cluster objects, only their icon is replaced. Hence they still react to normal events, and option `disableClusteringAtZoom` does not restore their previous icon (see [#391](https://github.com/Leaflet/Leaflet.markercluster/issues/391)).
-* **spiderLegPolylineOptions**: Allows you to specify [PolylineOptions](http://leafletjs.com/reference.html#polyline-options) to style spider legs. By default, they are `{ weight: 1.5, color: '#222' }`.
+* **spiderLegPolylineOptions**: Allows you to specify [PolylineOptions](http://leafletjs.com/reference.html#polyline-options) to style spider legs. By default, they are `{ weight: 1.5, color: '#222', opacity: 0.5 }`.
 * **spiderfyDistanceMultiplier**: Increase from 1 to increase the distance away from the center that spiderfied markers are placed. Use if you are using big marker icons (Default: 1).
 * **iconCreateFunction**: Function used to create the cluster icon [See default as example](https://github.com/Leaflet/Leaflet.markercluster/blob/15ed12654acdc54a4521789c498e4603fe4bf781/src/MarkerClusterGroup.js#L542).
 

--- a/dist/MarkerCluster.css
+++ b/dist/MarkerCluster.css
@@ -1,6 +1,14 @@
-.leaflet-cluster-anim .leaflet-marker-icon, .leaflet-cluster-anim .leaflet-marker-shadow, .leaflet-cluster-spider-leg {
-	-webkit-transition: -webkit-transform 0.3s ease-out, opacity 0.3s ease-in, -webkit-stroke-dashoffset 0.3s ease-out;
-	-moz-transition: -moz-transform 0.3s ease-out, opacity 0.3s ease-in, -moz-stroke-dashoffset 0.3s ease-out;
-	-o-transition: -o-transform 0.3s ease-out, opacity 0.3s ease-in, -o-stroke-dashoffset 0.3s ease-out;
-	transition: transform 0.3s ease-out, opacity 0.3s ease-in, stroke-dashoffset 0.3s ease-out;
+.leaflet-cluster-anim .leaflet-marker-icon, .leaflet-cluster-anim .leaflet-marker-shadow {
+	-webkit-transition: -webkit-transform 0.3s ease-out, opacity 0.3s ease-in;
+	-moz-transition: -moz-transform 0.3s ease-out, opacity 0.3s ease-in;
+	-o-transition: -o-transform 0.3s ease-out, opacity 0.3s ease-in;
+	transition: transform 0.3s ease-out, opacity 0.3s ease-in;
+}
+
+.leaflet-cluster-spider-leg {
+	/* stroke-dashoffset (duration and function) should match with leaflet-marker-icon transform in order to track it exactly */
+	-webkit-transition: -webkit-stroke-dashoffset 0.3s ease-out, -webkit-stroke-opacity 0.3s ease-in;
+	-moz-transition: -moz-stroke-dashoffset 0.3s ease-out, -moz-stroke-opacity 0.3s ease-in;
+	-o-transition: -o-stroke-dashoffset 0.3s ease-out, -o-stroke-opacity 0.3s ease-in;
+	transition: stroke-dashoffset 0.3s ease-out, stroke-opacity 0.3s ease-in;
 }

--- a/dist/MarkerCluster.css
+++ b/dist/MarkerCluster.css
@@ -1,6 +1,6 @@
-.leaflet-cluster-anim .leaflet-marker-icon, .leaflet-cluster-anim .leaflet-marker-shadow {
-	-webkit-transition: -webkit-transform 0.3s ease-out, opacity 0.3s ease-in;
-	-moz-transition: -moz-transform 0.3s ease-out, opacity 0.3s ease-in;
-	-o-transition: -o-transform 0.3s ease-out, opacity 0.3s ease-in;
-	transition: transform 0.3s ease-out, opacity 0.3s ease-in;
-	}
+.leaflet-cluster-anim .leaflet-marker-icon, .leaflet-cluster-anim .leaflet-marker-shadow, .leaflet-cluster-spider-leg {
+	-webkit-transition: -webkit-transform 0.3s ease-out, opacity 0.3s ease-in, -webkit-stroke-dashoffset 0.3s ease-out;
+	-moz-transition: -moz-transform 0.3s ease-out, opacity 0.3s ease-in, -moz-stroke-dashoffset 0.3s ease-out;
+	-o-transition: -o-transform 0.3s ease-out, opacity 0.3s ease-in, -o-stroke-dashoffset 0.3s ease-out;
+	transition: transform 0.3s ease-out, opacity 0.3s ease-in, stroke-dashoffset 0.3s ease-out;
+}

--- a/src/MarkerCluster.Spiderfier.js
+++ b/src/MarkerCluster.Spiderfier.js
@@ -168,7 +168,7 @@ L.MarkerCluster.include({
 			thisLayerLatLng = this._latlng,
 			thisLayerPos = map.latLngToLayerPoint(thisLayerLatLng),
 			svgAnim = L.Path.SVG && this.SVG_ANIMATION,
-			legOptions = this._group.options.spiderLegPolylineOptions,
+			legOptions = L.extend({}, this._group.options.spiderLegPolylineOptions), // Copy the options so that we can modify them for animation.
 			finalLegOpacity = legOptions.opacity,
 			i, m, leg, legPath, legLength, newPos;
 
@@ -176,8 +176,16 @@ L.MarkerCluster.include({
 			finalLegOpacity = L.MarkerClusterGroup.prototype.options.spiderLegPolylineOptions.opacity;
 		}
 
-		// Add the class for CSS transitions.
-		legOptions.className = (legOptions.className || '') + ' leaflet-cluster-spider-leg';
+		if (svgAnim) {
+			// If the initial opacity of the spider leg is not 0 then it appears before the animation starts.
+			legOptions.opacity = 0;
+
+			// Add the class for CSS transitions.
+			legOptions.className = (legOptions.className || '') + ' leaflet-cluster-spider-leg';
+		} else {
+			// Make sure we have a defined opacity.
+			legOptions.opacity = finalLegOpacity;
+		}
 
 		// Add markers and spider legs to map, hidden at our center point.
 		// Traverse in ascending order to make sure that inner circleMarkers are on top of further legs. Normal markers are re-ordered by newPosition.
@@ -189,11 +197,6 @@ L.MarkerCluster.include({
 
 			// Add the leg before the marker, so that in case the latter is a circleMarker, the leg is behind it.
 			leg = new L.Polyline([thisLayerLatLng, newPos], legOptions);
-
-			// If the initial opacity of the spider leg is not 0 then it appears before the animation starts.
-			if (svgAnim) {
-				leg.setStyle({opacity: 0});
-			}
 			map.addLayer(leg);
 			m._spiderLeg = leg;
 

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -32,7 +32,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		spiderfyDistanceMultiplier: 1,
 
 		// Make it possible to specify a polyline options on a spider leg
-		spiderLegPolylineOptions: { weight: 1.5, color: '#222' },
+		spiderLegPolylineOptions: { weight: 1.5, color: '#222', opacity: 0.5 },
 
 		// When bulk adding layers, adds markers in chunks. Means addLayers may not add all the layers in the call, others will be loaded during setTimeouts
 		chunkedLoading: false,


### PR DESCRIPTION
Following #554 and #584, experimented CSS transition to perform the spiderfy legs animations (should follow their markers, except in the case of circleMarkers which do not animate, but the legs do animate).

[CSS transition support](http://caniuse.com/#feat=css-transitions) should be broader than [SMIL](http://caniuse.com/#feat=svg-smil), in particular for IE.
I still made up a demo page and hopefully we can get people to test on different environments?
http://ghybs.github.io/Leaflet.markercluster/animateSpiderfyNoSMIL/marker-clustering-spiderfyAnimation-noSMIL.html

Works for me on FF and Chrome, but definitely not on IE8...

I created a new CSS class "leaflet-cluster-spider-leg" to add the transition (copied opacity, added stroke-dashoffset). This class is always added to the legs (no matter the `spiderLegPolylineOptions`).

Then the rest is quite simple and it decreases the amount of code:
- Just create the legs before the forced layout (took the opportunity to add them to the map before the markers, should solve #559).
- Set their path style strokeDasharray, strokeDashoffset and opacity like it was done with SMIL.
- After the re-layout, simply change the strokeDashoffset and opacity values and let the CSS transition work for us.

For unspiderfy, simply revert strokeDashoffset and opacity.