### PR TITLE
Correct _getExpandedVisibleBounds for Max Latitude

### DIFF
--- a/spec/suites/removeOutsideVisibleBoundsSpec.js
+++ b/spec/suites/removeOutsideVisibleBoundsSpec.js
@@ -129,7 +129,7 @@ describe('Option removeOutsideVisibleBounds', function () {
 
 
 	// Following tests need markers at very high latitude.
-	// They test the _checkBounds method against the default Web/Spherical Mercator projection maximum latitude (85.0511287798).
+	// They test the _checkBoundsMaxLat method against the default Web/Spherical Mercator projection maximum latitude (85.0511287798).
 	// The actual map view should be '-1.0986328125,84.92929204957956,1.0986328125,85.11983467698401'
 	// The expdanded bounds without correction should be '-3.2958984375,84.7387494221751,3.2958984375,85.31037730438847'
 	var latLngsMaxLatDefault = [

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -922,10 +922,10 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		if (!this.options.removeOutsideVisibleBounds) {
 			return this._mapBoundsInfinite;
 		} else if (L.Browser.mobile) {
-			return this._checkBounds(this._map.getBounds());
+			return this._checkBoundsMaxLat(this._map.getBounds());
 		}
 
-		return this._checkBounds(this._map.getBounds().pad(1)); // Padding expands the bounds by its own dimensions but scaled with the given factor.
+		return this._checkBoundsMaxLat(this._map.getBounds().pad(1)); // Padding expands the bounds by its own dimensions but scaled with the given factor.
 	},
 
 	/**
@@ -938,7 +938,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 	 * @returns {L.LatLngBounds}
 	 * @private
 	 */
-	_checkBounds: function (bounds) {
+	_checkBoundsMaxLat: function (bounds) {
 		var maxLat = this._maxLat;
 
 		if (maxLat !== undefined) {

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -929,9 +929,11 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 	},
 
 	/**
-	 * Expands the latitude to Infinity (or -Infinity) if the input bounds reach the map projection maximum defined latitude (in the case of Web/Spherical Mercator, it is 85.0511287798).
-	 * Otherwise, the removeOutsideVisibleBounds option will remove markers beyond that limit, whereas the same markers without this option (or outside MCG) will have their position
-	 * floored (ceiled) by the projection and rendered at that limit, making the user think MCG "eats" them and never displays them again.
+	 * Expands the latitude to Infinity (or -Infinity) if the input bounds reach the map projection maximum defined latitude
+	 * (in the case of Web/Spherical Mercator, it is 85.0511287798 / see https://en.wikipedia.org/wiki/Web_Mercator#Formulas).
+	 * Otherwise, the removeOutsideVisibleBounds option will remove markers beyond that limit, whereas the same markers without
+	 * this option (or outside MCG) will have their position floored (ceiled) by the projection and rendered at that limit,
+	 * making the user think that MCG "eats" them and never displays them again.
 	 * @param bounds L.LatLngBounds
 	 * @returns {L.LatLngBounds}
 	 * @private


### PR DESCRIPTION
Following #512, created a new private method in MCG `_checkBoundsMaxLat` that corrects output of `_getExpandedVisibleBounds` when the latter reaches the CRS projection maximum latitude (typically for Web/Spherical Mercator).

In that case, it extends the latitude to Infinity (or -Infinity in Southern hemisphere) so that all markers and clusters beyond the limit are added to the map. Indeed, when user adds markers directly to the map (not through MCG), if their latitude is above the limit, the projection will floor their position to the limit, so they will be visible within the map.

Without the correction, the map view bounds (even expanded) never reaches the very high latitudes, and MCG never adds markers and clusters at those positions. Hence they are never visible, even though they are counted as children of clusters at low zoom levels.

Also added 4 dedicated unit tests in removeOutsideVisibleBoundsSpec suite.