### PR TITLE
Replaced SMIL by requestAnimFrame for spiderLegs animation

### DIFF
--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -32,7 +32,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		spiderfyDistanceMultiplier: 1,
 
 		// Make it possible to specify a polyline options on a spider leg
-		spiderLegPolylineOptions: { weight: 1.5, color: '#222' },
+		spiderLegPolylineOptions: { weight: 1.5, color: '#222', opacity: 0.5 },
 
 		// When bulk adding layers, adds markers in chunks. Means addLayers may not add all the layers in the call, others will be loaded during setTimeouts
 		chunkedLoading: false,


### PR DESCRIPTION
this should add support to IE (and virtually any browser, thanks to Leaflet polyfill for requestAnimationFrame), as compared to SMIL and CSS Transitions on SVG properties.

Definitely more verbose than CSS Transition (almost same amount as SMIL).

Demo page: http://ghybs.github.io/Leaflet.markercluster/animateSpiderfyNoSMIL/marker-clustering-spiderfyAnimation-requestAnimFrame.html