### PR TITLE
Correct unspiderfy vector

### DIFF
--- a/spec/suites/removeOutsideVisibleBoundsSpec.js
+++ b/spec/suites/removeOutsideVisibleBoundsSpec.js
@@ -163,7 +163,6 @@ describe('Option removeOutsideVisibleBounds', function () {
 		var mapZoom = map.getZoom();
 
 		for (i = 0; i < markers.length; i++) {
-			markers[i].setLatLng(latLngs[i]);
 			try {
 				expect(markers[i].__parent._zoom).to.be.below(mapZoom);
 			} catch (e) {

--- a/src/MarkerCluster.Spiderfier.js
+++ b/src/MarkerCluster.Spiderfier.js
@@ -399,7 +399,7 @@ L.MarkerClusterGroup.include({
 			this._featureGroup.removeLayer(layer);
 
 			// L.Circle can be spiderfied, but only Markers have setOpacity and setZIndexOffset methods.
-			if (layer instanceof L.Marker) {
+			if (layer.setOpacity) {
 				layer.setOpacity(1);
 				//Position will be fixed up immediately in _animationUnspiderfy
 				layer.setZIndexOffset(0);

--- a/src/MarkerCluster.Spiderfier.js
+++ b/src/MarkerCluster.Spiderfier.js
@@ -398,7 +398,6 @@ L.MarkerClusterGroup.include({
 		if (layer._spiderLeg) {
 			this._featureGroup.removeLayer(layer);
 
-			// L.Circle can be spiderfied, but only Markers have setOpacity and setZIndexOffset methods.
 			if (layer.setOpacity) {
 				layer.setOpacity(1);
 				//Position will be fixed up immediately in _animationUnspiderfy

--- a/src/MarkerCluster.Spiderfier.js
+++ b/src/MarkerCluster.Spiderfier.js
@@ -203,21 +203,23 @@ L.MarkerCluster.include({
 			if (svg) {
 				legPath = leg._path;
 				legLength = legPath.getTotalLength() + 0.1; // Need a small extra length to avoid remaining dot in Firefox.
-				legPath.style.strokeDasharray = legLength + ' ' + legLength;
+				legPath.style.strokeDasharray = legLength; // Just 1 length is enough, it will be duplicated.
 				legPath.style.strokeDashoffset = legLength;
 			}
 
 			// If it is a marker, add it now and we'll animate it out
-			if (m.setOpacity) {
+			if (m.setZIndexOffset) {
 				m.setZIndexOffset(1000000); // Make normal markers appear on top of EVERYTHING
+			}
+			if (m.clusterHide) {
 				m.clusterHide();
-			
-				fg.addLayer(m);
+			}
 
+			// Vectors just get immediately added
+			fg.addLayer(m);
+
+			if (m._setPos) {
 				m._setPos(thisLayerPos);
-			} else {
-				// Vectors just get immediately added
-				fg.addLayer(m);
 			}
 		}
 
@@ -233,7 +235,7 @@ L.MarkerCluster.include({
 			m._preSpiderfyLatlng = m._latlng;
 			m.setLatLng(newPos);
 			
-			if (m.setOpacity) {
+			if (m.clusterShow) {
 				m.clusterShow();
 			}
 
@@ -261,7 +263,7 @@ L.MarkerCluster.include({
 			thisLayerPos = zoomDetails ? map._latLngToNewLayerPoint(this._latlng, zoomDetails.zoom, zoomDetails.center) : map.latLngToLayerPoint(this._latlng),
 			childMarkers = this.getAllChildMarkers(),
 			svg = L.Path.SVG,
-			m, i, leg, legPath, legLength;
+			m, i, leg, legPath, legLength, nonAnimatable;
 
 		group._animationStart();
 
@@ -278,11 +280,18 @@ L.MarkerCluster.include({
 			//Fix up the location to the real one
 			m.setLatLng(m._preSpiderfyLatlng);
 			delete m._preSpiderfyLatlng;
+
 			//Hack override the location to be our center
-			if (m.setOpacity) {
+			nonAnimatable = true;
+			if (m._setPos) {
 				m._setPos(thisLayerPos);
+				nonAnimatable = false;
+			}
+			if (m.clusterHide) {
 				m.clusterHide();
-			} else {
+				nonAnimatable = false;
+			}
+			if (nonAnimatable) {
 				fg.removeLayer(m);
 			}
 
@@ -314,9 +323,10 @@ L.MarkerCluster.include({
 					continue;
 				}
 
-
-				if (m.setOpacity) {
+				if (m.clusterShow) {
 					m.clusterShow();
+				}
+				if (m.setZIndexOffset) {
 					m.setZIndexOffset(0);
 				}
 
@@ -355,7 +365,6 @@ L.MarkerClusterGroup.include({
 		this._unspiderfy(); //Ensure that markers are back where they should be
 	},
 
-
 	//On zoom start we add a zoomanim handler so that we are guaranteed to be last (after markers are animated)
 	//This means we can define the animation they do rather than Markers doing an animation to their actual location
 	_unspiderfyZoomStart: function () {
@@ -365,6 +374,7 @@ L.MarkerClusterGroup.include({
 
 		this._map.on('zoomanim', this._unspiderfyZoomAnim, this);
 	},
+
 	_unspiderfyZoomAnim: function (zoomDetails) {
 		//Wait until the first zoomanim after the user has finished touch-zooming before running the animation
 		if (L.DomUtil.hasClass(this._map._mapPane, 'leaflet-touching')) {
@@ -374,7 +384,6 @@ L.MarkerClusterGroup.include({
 		this._map.off('zoomanim', this._unspiderfyZoomAnim, this);
 		this._unspiderfy(zoomDetails);
 	},
-
 
 	_unspiderfyWrapper: function () {
 		/// <summary>_unspiderfy but passes no arguments</summary>
@@ -398,9 +407,11 @@ L.MarkerClusterGroup.include({
 		if (layer._spiderLeg) {
 			this._featureGroup.removeLayer(layer);
 
-			if (layer.setOpacity) {
-				layer.setOpacity(1);
-				//Position will be fixed up immediately in _animationUnspiderfy
+			if (layer.clusterShow) {
+				layer.clusterShow();
+			}
+			//Position will be fixed up immediately in _animationUnspiderfy
+			if (layer.setZIndexOffset) {
 				layer.setZIndexOffset(0);
 			}
 

--- a/src/MarkerCluster.Spiderfier.js
+++ b/src/MarkerCluster.Spiderfier.js
@@ -398,9 +398,12 @@ L.MarkerClusterGroup.include({
 		if (layer._spiderLeg) {
 			this._featureGroup.removeLayer(layer);
 
-			layer.setOpacity(1);
-			//Position will be fixed up immediately in _animationUnspiderfy
-			layer.setZIndexOffset(0);
+			// L.Circle can be spiderfied, but only Markers have setOpacity and setZIndexOffset methods.
+			if (layer instanceof L.Marker) {
+				layer.setOpacity(1);
+				//Position will be fixed up immediately in _animationUnspiderfy
+				layer.setZIndexOffset(0);
+			}
 
 			this._map.removeLayer(layer._spiderLeg);
 			delete layer._spiderLeg;


### PR DESCRIPTION
L.Circle has `_latLng` and as such can be clustered and spiderfied. However, when unspiderfying, L.Circle does not have the `setOpacity` nor `setZIndexOffset` methods of L.Marker.

Also corrected removeOutsideVisibleBoundsSpec test suite.