### PR TITLE
Spiderfy at current zoom if all child markers still in single cluster at maxZoom

### DIFF
--- a/spec/suites/spiderfySpec.js
+++ b/spec/suites/spiderfySpec.js
@@ -68,6 +68,68 @@
 		expect(marker2._container.parentNode).to.be(map._pathRoot);
 	});
 
+	it('Spiderfies at current zoom if all child markers are at the exact same position', function () {
+
+		var group = new L.MarkerClusterGroup();
+		var marker = new L.Marker([1.5, 1.5]);
+		var marker2 = new L.Marker([1.5, 1.5]);
+
+		group.addLayers([marker, marker2]);
+		map.addLayer(group);
+
+		// Get the appropriate cluster.
+		var cluster = marker.__parent,
+		    zoom = map.getZoom();
+
+		while (cluster._zoom !== zoom) {
+			cluster = cluster.__parent;
+		}
+
+		expect(zoom).to.be.lessThan(10);
+
+		cluster.fireEvent('click');
+
+		clock.tick(1000);
+
+		expect(map.getZoom()).to.equal(zoom);
+
+		expect(marker._icon.parentNode).to.be(map._panes.markerPane);
+		expect(marker2._icon.parentNode).to.be(map._panes.markerPane);
+
+	});
+
+	it('Spiderfies at current zoom if all child markers are still within a single cluster at map maxZoom', function () {
+
+		var group = new L.MarkerClusterGroup();
+		var marker = new L.Marker([1.5, 1.50001]);
+		var marker2 = new L.Marker([1.5, 1.5]);
+
+		group.addLayers([marker, marker2]);
+		map.addLayer(group);
+
+		expect(marker.__parent._zoom).to.equal(18);
+
+		// Get the appropriate cluster.
+		var cluster = marker.__parent,
+		    zoom = map.getZoom();
+
+		while (cluster._zoom !== zoom) {
+			cluster = cluster.__parent;
+		}
+
+		expect(zoom).to.be.lessThan(10);
+
+		cluster.fireEvent('click');
+
+		clock.tick(1000);
+
+		expect(map.getZoom()).to.equal(zoom);
+
+		expect(marker._icon.parentNode).to.be(map._panes.markerPane);
+		expect(marker2._icon.parentNode).to.be(map._panes.markerPane);
+
+	});
+
 	describe('zoomend event listener', function () {
 		it('unspiderfies correctly', function () {
 

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -709,17 +709,17 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 	},
 
 	_zoomOrSpiderfy: function (e) {
-		var map = this._map;
-		if (e.layer._bounds._northEast.equals(e.layer._bounds._southWest)) {
+		var map = this._map,
+		    cluster = e.layer,
+		    someChildMarkerParent = cluster.getAllChildMarkers()[0].__parent;
+
+		if (someChildMarkerParent._zoom === map.getMaxZoom() && someChildMarkerParent._childCount === cluster._childCount) {
+			// All child markers are contained in a single cluster from map._maxZoom to this cluster.
 			if (this.options.spiderfyOnMaxZoom) {
-				e.layer.spiderfy();
-			}
-		} else if (map.getMaxZoom() === map.getZoom()) {
-			if (this.options.spiderfyOnMaxZoom) {
-				e.layer.spiderfy();
+				cluster.spiderfy();
 			}
 		} else if (this.options.zoomToBoundsOnClick) {
-			e.layer.zoomToBounds();
+			cluster.zoomToBounds();
 		}
 
 		// Focus the map again for keyboard users.

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -711,9 +711,13 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 	_zoomOrSpiderfy: function (e) {
 		var map = this._map,
 		    cluster = e.layer,
-		    someChildMarkerParent = cluster.getAllChildMarkers()[0].__parent;
+			bottomCluster = cluster;
 
-		if (someChildMarkerParent._zoom === map.getMaxZoom() && someChildMarkerParent._childCount === cluster._childCount) {
+		while (bottomCluster._childClusters.length) {
+			bottomCluster = bottomCluster._childClusters[0];
+		} // bottomCluster is not necessarily the bottom-most one, but in that case we should not spiderfy anyway.
+
+		if (bottomCluster._zoom === map.getMaxZoom() && bottomCluster._childCount === cluster._childCount) {
 			// All child markers are contained in a single cluster from map._maxZoom to this cluster.
 			if (this.options.spiderfyOnMaxZoom) {
 				cluster.spiderfy();

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -713,9 +713,9 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		    cluster = e.layer,
 			bottomCluster = cluster;
 
-		while (bottomCluster._childClusters.length) {
+		while (bottomCluster._childClusters.length === 1) {
 			bottomCluster = bottomCluster._childClusters[0];
-		} // bottomCluster is not necessarily the bottom-most one, but in that case we should not spiderfy anyway.
+		}
 
 		if (bottomCluster._zoom === map.getMaxZoom() && bottomCluster._childCount === cluster._childCount) {
 			// All child markers are contained in a single cluster from map._maxZoom to this cluster.

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -711,7 +711,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 	_zoomOrSpiderfy: function (e) {
 		var map = this._map,
 		    cluster = e.layer,
-			bottomCluster = cluster;
+		    bottomCluster = cluster;
 
 		while (bottomCluster._childClusters.length === 1) {
 			bottomCluster = bottomCluster._childClusters[0];


### PR DESCRIPTION
Current code in `_zoomOrSpiderfy` spiderfies at current zoom only if **all** child markers are at the **exact** same position (i.e. cluster bounds is a point) (or if we are at max zoom already obviously).

That means that if markers are at **slightly different** positions, but if they are all still in a single cluster at maximum zoom, clicking on the cluster will zoom to that max zoom level, but user will still see the "same" cluster, and no markers. And he/she will need a second click to trigger the spiderfy. This is exactly what the current code was trying to avoid.

Since current MCG does not display any clue about the true markers position anyway (spider legs point at the cluster position, not at true positions), there is no point zooming to maximum zoom in that case either.

This PR checks if all child markers are still within a single cluster at maximum zoom, instead of checking for cluster bounds being a point.

Demo of the 2 different behaviours here: http://jsfiddle.net/ve2huzxw/50/

I also included 2 extra tests in spiderfierSpec test suite to cover these cases.