### PR TITLE
Added sub-plugin MCG.Freezable (on to README page)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,3 +261,4 @@ Check also the below sub-plugins:
 | :----- | :---------- | :--------- |
 | [Leaflet.FeatureGroup.SubGroup](https://github.com/ghybs/Leaflet.FeatureGroup.SubGroup) | Creates a Feature Group that adds its child layers into a parent group when added to a map (e.g. through L.Control.Layers). Typical usage is to dynamically add/remove groups of markers from Marker Cluster. | [ghybs](https://github.com/ghybs) |
 | [Leaflet.MarkerCluster.LayerSupport](https://github.com/ghybs/Leaflet.MarkerCluster.LayerSupport) | Brings compatibility with L.Control.Layers and other Leaflet plugins. I.e. everything that uses direct calls to map.addLayer and map.removeLayer. | [ghybs](https://github.com/ghybs) |
+| [Leaflet.MarkerCluster.Freezable](https://github.com/ghybs/Leaflet.MarkerCluster.Freezable) | Adds the ability to freeze clusters at a specified zoom. E.g. freezing at maxZoom + 1 makes as if clustering was programmatically disabled. | [ghybs](https://github.com/ghybs) |


### PR DESCRIPTION
This plugin directly adds new methods to MCG. It becomes possible "freezing" clusters at a given arbitrary zoom level. In particular, freezing at maxZoom + 1 makes as if MCG was disabled. Freezing at maxZoom makes as if MCG was disabled except for the bottom-most clusters with spiderfication.

Found following related issues / feature requests: #98, #112, #173, #339, #534, #552.
It goes also a step forward #499.

However #399 would probably still need something more sophisticated as it would require applying the same principle on a cluster's zoom basis rather than for the whole group's zoom.