### PR TITLE
Fix click to zoom at disable clustering zoom level

### DIFF
--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -799,7 +799,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 			bottomCluster = bottomCluster._childClusters[0];
 		}
 
-		if (bottomCluster._zoom === this._maxZoom && bottomCluster._childCount === cluster._childCount) {
+		if (bottomCluster._zoom === this._map.getMaxZoom() && bottomCluster._childCount === cluster._childCount) {
 			// All child markers are contained in a single cluster from this._maxZoom to this cluster.
 			if (this.options.spiderfyOnMaxZoom) {
 				cluster.spiderfy();


### PR DESCRIPTION
With `disableClusteringAtZoom` on and `spiderfyOnMaxZoom` off, this would simply do nothing when clicking on a cluster at the zoom level before clustering is disabled.

Now with `spiderfyOnMaxZoom` not disabled, it will only spiderfy at the **map's** max zoom rather than the zoom level configured for `disableClusteringAtZoom` (the **cluster's** max zoom). Is this the expected behaviour?

Note: we're having this issue with the v1.0.0-beta.2.0 version, it seems it wasn't an issue in v0.4.0