### PR TITLE
Replaced `dependencies` by `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"repository": "https://github.com/Leaflet/Leaflet.markercluster",
 	"version": "0.4.0",
 	"description": "Provides Beautiful Animated Marker Clustering functionality for Leaflet",
-	"dependencies": {
+	"peerDependencies": {
 		"leaflet": "~1.0.0-beta.2"
 	},
 	"devDependencies": {


### PR DESCRIPTION
in `package.json` to specify the Leaflet version for which Leaflet.markercluster is compatible with, following issue #639.

`peerDependencies` as described in https://docs.npmjs.com/files/package.json#peerdependencies

Maybe take the opportunity to loosen the Leaflet version?
And also to change the Leaflet.markercluster version?