### PR TITLE
Optimized performance of bulk add with complex icon create function

### DIFF
--- a/src/MarkerClusterGroup.Refresh.js
+++ b/src/MarkerClusterGroup.Refresh.js
@@ -62,19 +62,6 @@ L.MarkerClusterGroup.include({
 	},
 
 	/**
-	 * Refreshes the icon of all "dirty" visible clusters.
-	 * Non-visible "dirty" clusters will be updated when they are added to the map.
-	 * @private
-	 */
-	_refreshClustersIcons: function () {
-		this._featureGroup.eachLayer(function (c) {
-			if (c instanceof L.MarkerCluster && c._iconNeedsUpdate) {
-				c._updateIcon();
-			}
-		});
-	},
-
-	/**
 	 * Re-draws the icon of the supplied markers.
 	 * To be used in singleMarkerMode only.
 	 * @param layers Array(L.Marker)|Map(L.Marker) list of markers.

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -104,6 +104,8 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		// Refresh bounds and weighted positions.
 		this._topClusterLevel._recalculateBounds();
 
+		this._refreshClustersIcons();
+
 		//Work out what is visible
 		var visibleLayer = layer,
 			currentZoom = this._map.getZoom();
@@ -156,6 +158,8 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 
 		// Refresh bounds and weighted positions.
 		this._topClusterLevel._recalculateBounds();
+
+		this._refreshClustersIcons();
 
 		layer.off('move', this._childMarkerMoved, this);
 
@@ -249,12 +253,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 					// Refresh bounds and weighted positions.
 					this._topClusterLevel._recalculateBounds();
 
-					//Update the icons of all those visible clusters that were affected
-					this._featureGroup.eachLayer(function (c) {
-						if (c instanceof L.MarkerCluster && c._iconNeedsUpdate) {
-							c._updateIcon();
-						}
-					});
+					this._refreshClustersIcons();
 
 					this._topClusterLevel._recursivelyAddChildrenToMap(null, this._zoom, this._currentShownBounds);
 				} else {
@@ -380,14 +379,10 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		// Refresh bounds and weighted positions.
 		this._topClusterLevel._recalculateBounds();
 
+		this._refreshClustersIcons();
+
 		//Fix up the clusters and markers on the map
 		this._topClusterLevel._recursivelyAddChildrenToMap(null, this._zoom, this._currentShownBounds);
-
-		fg.eachLayer(function (c) {
-			if (c instanceof L.MarkerCluster) {
-				c._updateIcon();
-			}
-		});
 
 		return this;
 	},
@@ -717,9 +712,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 					}
 				}
 			} else {
-				if (!dontUpdateMap || !cluster._icon) {
-					cluster._updateIcon();
-				}
+				cluster._iconNeedsUpdate = true;
 			}
 
 			cluster = cluster.__parent;
@@ -966,6 +959,19 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		this._topClusterLevel._addChild(layer);
 		layer.__parent = this._topClusterLevel;
 		return;
+	},
+
+	/**
+	 * Refreshes the icon of all "dirty" visible clusters.
+	 * Non-visible "dirty" clusters will be updated when they are added to the map.
+	 * @private
+	 */
+	_refreshClustersIcons: function () {
+		this._featureGroup.eachLayer(function (c) {
+			if (c instanceof L.MarkerCluster && c._iconNeedsUpdate) {
+				c._updateIcon();
+			}
+		});
 	},
 
 	//Enqueue code to fire after the marker expand/contract has happened


### PR DESCRIPTION
Unified invalidating of icons to match that of bounds (#584).

The improvement is most (only?) apparent with `addLayers` when function for generating icon is complex (e.g. uses `getAllChildMarkers`) and the view is zoomed out, so that markers are added to existing cluster with a high humber of points. Basic example (time is written to console):

- original: https://qedsoftware.github.io/Leaflet.markercluster/icon-performance/marker-clustering-realworld.50000.html
- optimized: https://qedsoftware.github.io/Leaflet.markercluster/icon-performance/marker-clustering-realworld.50000-after.html

With such a basic example, on latest Safari & Chrome it's a reduction from ~6s to ~300ms. In our case (icons based on [PruneCluster categories](http://sintef-9012.github.io/PruneCluster/examples/random.10000-categories.html), leaflet 0.7) it's from 1 minute to ~300ms.