### PR TITLE
Get map zoom from internal _zoom for compatibility with Freezable sub-plugin

### DIFF
--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -108,7 +108,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 
 		//Work out what is visible
 		var visibleLayer = layer,
-			currentZoom = this._map.getZoom();
+		    currentZoom = this._zoom;
 		if (layer.__parent) {
 			while (visibleLayer.__parent._zoom >= currentZoom) {
 				visibleLayer = visibleLayer.__parent;
@@ -1251,7 +1251,7 @@ L.MarkerClusterGroup.include({
 					this._forceLayout();
 
 					me._animationStart();
-					me._animationZoomOutSingle(newCluster, this._map.getMaxZoom(), this._map.getZoom());
+					me._animationZoomOutSingle(newCluster, this._map.getMaxZoom(), this._zoom);
 				}
 			}
 		}

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -527,7 +527,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		if (layer._icon && this._map.getBounds().contains(layer.getLatLng())) {
 			//Layer is visible ond on screen, immediate return
 			callback();
-		} else if (layer.__parent._zoom < this._map.getZoom()) {
+		} else if (layer.__parent._zoom < Math.round(this._map._zoom)) {
 			//Layer should be visible at this zoom level. It must not be on screen so just pan over to it
 			this._map.on('moveend', showMarker, this);
 			this._map.panTo(layer.getLatLng());
@@ -574,7 +574,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		this._needsRemoving = [];
 
 		//Remember the current zoom level and bounds
-		this._zoom = this._map.getZoom();
+		this._zoom = Math.round(this._map._zoom);
 		this._currentShownBounds = this._getExpandedVisibleBounds();
 
 		this._map.on('zoomend', this._zoomEnd, this);


### PR DESCRIPTION
Get the map zoom from internal `_zoom` in `addLayer` and `_animationAddLayer` methods, for compatibility with MCG.Freezable plugin (see issue ghybs/Leaflet.MarkerCluster.Freezable#1).

In normal situation (i.e. without Freezable plugin), the 2 should differ only momentarily at the end of a zoom, before the `_zoomEnd` listener is called, and until that listener completes.
If `addLayer` happens before the listener is called, it should perform as if the zoom did not occur yet, then `_zoomEnd` proceeds with the new layer / cluster without issue.
`addLayer` should not be able to execute in the middle of `_zoomEnd`, as there is no asynchronous task involved, except for the end of the zoom animation, where previous clusters are collected. For that one, `_zoom` is already updated to equal `map._zoom`, so there is no change compared to before this commit.
As a conclusion, this commit _should_ not change anything to MCG.

When Freezable plugin is added, it tampers `_zoom` and listeners to disable changes and animations. So MCG should no longer call `map.getZoom()` / `map._zoom` outside the disabled listeners.

I also took the opportunity to replace `map.getZoom()` by direct access to `map._zoom` (or `_zoom`) and to add missing `Math.round()` for consistency.