### PR TITLE
README plugin install details

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,15 @@ removed link to h1 and indented back 2 spaces all links.
 
 
 ## Using the plugin
-Install with npm: `npm install leaflet.markercluster`
+Include the plugin CSS and JS files on your page after Leaflet files, using your method of choice:
+* [Download the `v1.0.0` release](https://github.com/Leaflet/Leaflet.markercluster/archive/v1.0.0.zip)
+* Use unpkg CDN: `https://unpkg.com/leaflet.markercluster@1.0.0/dist/`
+* Install with npm: `npm install leaflet.markercluster`
+
+In each case, use files in the `dist` folder:
+* `MarkerCluster.css`
+* `MarkerCluster.Default.css` (not needed if you use your own `createIconFunction` instead of the default one)
+* `leaflet.markercluster.js` (or `leaflet.markercluster-src.js` for the non-minified version)
 
 ### Building, testing and linting scripts
 Install jake `npm install -g jake` then run `npm install`

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ removed link to h1 and indented back 2 spaces all links.
 -->
 ## Table of Contents
   * [Using the plugin](#using-the-plugin)
-    * [Usage](#usage)
     * [Building, testing and linting scripts](#building-testing-and-linting-scripts)
     * [Examples](#examples)
+    * [Usage](#usage)
   * [Options](#options)
     * [Defaults](#defaults)
     * [Customising the Clustered Markers](#customising-the-clustered-markers)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Include the plugin CSS and JS files on your page after Leaflet files, using your
 
 In each case, use files in the `dist` folder:
 * `MarkerCluster.css`
-* `MarkerCluster.Default.css` (not needed if you use your own `createIconFunction` instead of the default one)
+* `MarkerCluster.Default.css` (not needed if you use your own `iconCreateFunction` instead of the default one)
 * `leaflet.markercluster.js` (or `leaflet.markercluster-src.js` for the non-minified version)
 
 ### Building, testing and linting scripts


### PR DESCRIPTION
- Improved plugin installation instructions (added local copy and CDN options), should address #713
- Corrected TOC order for first section

Local copy is a link to directly download `v1.0.0` release zip archive from GitHub.

CDN uses unpkg (based on npm), like Leaflet officially recommended CDN.