### PR TITLE
Fixed leaflet 1.0.2 bug where clearLayers would throw an exception

### DIFF
--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -409,7 +409,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		this.eachLayer(function (marker) {
 			marker.off('move', this._childMarkerMoved, this);
 			delete marker.__parent;
-		});
+		}, this);
 
 		if (this._map) {
 			//Reset _topClusterLevel and the DistanceGrids


### PR DESCRIPTION
The exception was that the function 'this._childmarkerMoved' could not be found because the context was not known. So I passed the context in the 'eachLayer' function