### PR TITLE
Fixed zoomToShowLayer() markers disappearing bug

### DIFF
--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -542,10 +542,13 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 			this.on('animationend', showMarker, this);
 			layer.__parent.zoomToBounds();
 
-			if (moveStart) {
-				//Never started moving, must already be there, probably need clustering however
-				showMarker.call(this);
-			}
+			//Delay execution to handle events
+			setTimeout(function () {
+				if (moveStart) {
+					//Never started moving, must already be there, probably need clustering however
+					showMarker.call(this);
+				}
+			});
 		}
 	},
 

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -505,7 +505,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 
 	//Zoom down to show the given layer (spiderfying if necessary) then calls the callback
 	zoomToShowLayer: function (layer, callback) {
-		
+
 		if (typeof callback !== 'function') {
 			callback = function () {};
 		}
@@ -532,23 +532,9 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 			this._map.on('moveend', showMarker, this);
 			this._map.panTo(layer.getLatLng());
 		} else {
-			var moveStart = function () {
-				this._map.off('movestart', moveStart, this);
-				moveStart = null;
-			};
-
-			this._map.on('movestart', moveStart, this);
 			this._map.on('moveend', showMarker, this);
 			this.on('animationend', showMarker, this);
 			layer.__parent.zoomToBounds();
-
-			//Delay execution to handle events
-			setTimeout(function () {
-				if (moveStart) {
-					//Never started moving, must already be there, probably need clustering however
-					showMarker.call(this);
-				}
-			});
 		}
 	},
 


### PR DESCRIPTION
Hello,
this will fix https://github.com/Leaflet/Leaflet.markercluster/issues/739

Timeout allows to handle map movestart event before checking it execution, so layer parent won't spiderfy when move start.

Fixed example from issue http://codepen.io/anon/pen/wgBBJV