### PR TITLE
RFC Handle ES6 iterators in addLayers()

### DIFF
--- a/spec/suites/AddLayersSpec.js
+++ b/spec/suites/AddLayersSpec.js
@@ -148,6 +148,43 @@
 		expect(map._panes.markerPane.childNodes.length).to.be(2);
 	});
 
+	it('handles ES6 iterators that yield Markers and LayerGroups', function () {
+
+		group = new L.MarkerClusterGroup();
+
+		var marker1 = new L.Marker([1.5, 1.5]);
+		var marker2 = new L.Marker([1.5, 1.5]);
+		var marker3 = new L.Marker([3.0, 1.5]);
+		var layerGroup = new L.LayerGroup([marker1, new L.LayerGroup([marker2])]);
+
+		// Simulate an ES6 iterator which is ES5 compatible where generator
+		// functions are not. This allows us to test the functionality without the
+		// need to skip the test in non ES6 compatible browsers like we would need
+		// to if we used a generator function. This functionality will allow users
+		// of ES6 to interface with Leaflet eventhough leaflet is not strickly ES6
+		// based.
+		var fakeIterator = {
+			_pointer: 0;
+			next: function() {
+				this._pointer++;
+				switch (this._pointer) {
+					case 1: return {done: false, value: layerGroup};
+					case 2: return {done: false, value: marker3};
+					default: return {done: true};
+				}
+			}
+		};
+
+		map.addLayer(group);
+		group.addLayers(fakeIterator);
+
+		expect(marker1._icon).to.be(undefined);
+		expect(marker2._icon).to.be(undefined);
+		expect(marker3._icon.parentNode).to.be(map._panes.markerPane);
+
+		expect(map._panes.markerPane.childNodes.length).to.be(2);
+	});
+
 
 	/////////////////////////////
 	// CLEAN UP CODE


### PR DESCRIPTION
This is an initial attempt to spec out what would be expected if this plugin supported ES6 iterators.

An example usage might look like:

```js
function *mapMarkers() {
  yield new L.Marker([1.5, 1.5]);
  yield new L.Marker([1.5, 1.5]);
  yield new L.Marker([3.0, 1.5]);
}

var group = new L.MarkerClusterGroup();
group.addLayers(mapMarkers());
```

This (slightly contrived) example could allow the clustering logic to perform batch processing more efficiently and with less memory over head.

An example real world case would be when markers are constructed from Lat/Lng data. In Array based code one has to map over the array to make a interim Array of `L.Markers` which are passed to `addLayers` which has to iterate over the array a second time. With the use of an iterator (typically produced from a generator function) that pipeline could be reduced considerably by only processing the mapping at the time it is needed. This means that the interim array described above would not exists while the `addLayers` batch processed. It also means that the memory required would only be a large as the number of markers being processed in any given run loop.

Comparison of a clustering with iterators the consumption would be at most 1 at a time plus the final set. While without you would have the interim mapping of markers plus the final set. This results in `N+1` VS. `2N`.

This PR is meant as a starting point for discussion (RFC). It currently is simply a spec around the API usage. Actual implementation *might* result in a significant rewrite or separate branch of logic. The pro and cons needs to be clearly discussed before determining if an implementation of this feature is worth consideration.