### PR TITLE
Docs(README): use https for demo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Install jake `npm install -g jake` then run `npm install`
 ### Examples
 See the included examples for usage.
 
-The [realworld example](http://leaflet.github.io/Leaflet.markercluster/example/marker-clustering-realworld.388.html) is a good place to start, it uses all of the defaults of the clusterer.
-Or check out the [custom example](http://leaflet.github.io/Leaflet.markercluster/example/marker-clustering-custom.html) for how to customise the behaviour and appearance of the clusterer
+The [realworld example](https://leaflet.github.io/Leaflet.markercluster/example/marker-clustering-realworld.388.html) is a good place to start, it uses all of the defaults of the clusterer.
+Or check out the [custom example](https://leaflet.github.io/Leaflet.markercluster/example/marker-clustering-custom.html) for how to customise the behaviour and appearance of the clusterer
 
 ### Usage
 Create a new MarkerClusterGroup, add your markers to it, then add it to the map
@@ -109,7 +109,7 @@ var markers = L.markerClusterGroup({
 	}
 });
 ```
-Check out the [custom example](http://leaflet.github.io/Leaflet.markercluster/example/marker-clustering-custom.html) for an example of this.
+Check out the [custom example](https://leaflet.github.io/Leaflet.markercluster/example/marker-clustering-custom.html) for an example of this.
 
 If you need to update the clusters icon (e.g. they are based on markers real-time data), use the method [refreshClusters()](#refreshing-the-clusters-icon).
 
@@ -123,7 +123,7 @@ If you need to update the clusters icon (e.g. they are based on markers real-tim
 
 #### Other options
 * **animateAddingMarkers**: If set to true (and `animate` option is also true) then adding individual markers to the MarkerClusterGroup after it has been added to the map will add the marker and animate it into the cluster. Defaults to false as this gives better performance when bulk adding markers. addLayers does not support this, only addLayer with individual Markers.
-* **disableClusteringAtZoom**: If set, at this zoom level and below, markers will not be clustered. This defaults to disabled. [See Example](http://leaflet.github.io/Leaflet.markercluster/example/marker-clustering-realworld-maxzoom.388.html). Note: you may be interested in disabling `spiderfyOnMaxZoom` option when using `disableClusteringAtZoom`.
+* **disableClusteringAtZoom**: If set, at this zoom level and below, markers will not be clustered. This defaults to disabled. [See Example](https://leaflet.github.io/Leaflet.markercluster/example/marker-clustering-realworld-maxzoom.388.html). Note: you may be interested in disabling `spiderfyOnMaxZoom` option when using `disableClusteringAtZoom`.
 * **maxClusterRadius**: The maximum radius that a cluster will cover from the central marker (in pixels). Default 80. Decreasing will make more, smaller clusters. You can also use a function that accepts the current map zoom and returns the maximum cluster radius in pixels.
 * **polygonOptions**: Options to pass when creating the L.Polygon(points, options) to show the bounds of a cluster. Defaults to empty, which lets Leaflet use the [default Path options](http://leafletjs.com/reference.html#path-options).
 * **singleMarkerMode**: If set to true, overrides the icon for all added markers to make them appear as a 1 size cluster. Note: the markers are not replaced by cluster objects, only their icon is replaced. Hence they still react to normal events, and option `disableClusteringAtZoom` does not restore their previous icon (see [#391](https://github.com/Leaflet/Leaflet.markercluster/issues/391)).
@@ -234,7 +234,7 @@ markers.on('clusterclick', function (a) {
 ```
 
 You can also query for the bounding convex polygon.
-See [example/marker-clustering-convexhull.html](http://leaflet.github.io/Leaflet.markercluster/example/marker-clustering-convexhull.html) for a working example.
+See [example/marker-clustering-convexhull.html](https://leaflet.github.io/Leaflet.markercluster/example/marker-clustering-convexhull.html) for a working example.
 ```javascript
 markers.on('clusterclick', function (a) {
 	map.addLayer(L.polygon(a.layer.getConvexHull()));
@@ -246,7 +246,7 @@ When you receive an event from a cluster you can zoom to its bounds in one easy 
 If all of the markers will appear at a higher zoom level, that zoom level is zoomed to instead.
 `zoomToBounds` takes an optional argument to pass [options to the resulting `fitBounds` call](http://leafletjs.com/reference.html#map-fitboundsoptions).
 
-See [marker-clustering-zoomtobounds.html](http://leaflet.github.io/Leaflet.markercluster/example/marker-clustering-zoomtobounds.html) for a working example.
+See [marker-clustering-zoomtobounds.html](https://leaflet.github.io/Leaflet.markercluster/example/marker-clustering-zoomtobounds.html) for a working example.
 ```javascript
 markers.on('clusterclick', function (a) {
 	a.layer.zoomToBounds({padding: [20, 20]});
@@ -261,8 +261,8 @@ markers.on('clusterclick', function (a) {
 
 ## Handling LOTS of markers
 The Clusterer can handle 10,000 or even 50,000 markers (in chrome). IE9 has some issues with 50,000.
-- [realworld 10,000 example](http://leaflet.github.io/Leaflet.markercluster/example/marker-clustering-realworld.10000.html)
-- [realworld 50,000 example](http://leaflet.github.io/Leaflet.markercluster/example/marker-clustering-realworld.50000.html)
+- [realworld 10,000 example](https://leaflet.github.io/Leaflet.markercluster/example/marker-clustering-realworld.10000.html)
+- [realworld 50,000 example](https://leaflet.github.io/Leaflet.markercluster/example/marker-clustering-realworld.50000.html)
 
 Note: these two examples use the `chunkedLoading` option set to true in order to avoid locking the browser for a long time.
 


### PR DESCRIPTION
instead of `http`, now that we have `https` CDN for Leaflet.