### PR TITLE
Automatically aborts adding additional markers for an ongoing addLayers calls when the clearLayers function is called.

### DIFF
--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -509,7 +509,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 	//Overrides LayerGroup.getLayer, WARNING: Really bad performance
 	getLayer: function (id) {
 		var result = null;
-
+		
 		id = parseInt(id, 10);
 
 		this.eachLayer(function (l) {
@@ -723,7 +723,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		}
 		delete e.target.__dragStart;
 	},
-
+	
 
 	//Internal function for removing a marker from everything.
 	//dontUpdateMap: set to true if you will handle updating the map manually (for bulk functions)
@@ -937,7 +937,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 			minZoom = Math.floor(this._map.getMinZoom()),
 			radius = this.options.maxClusterRadius,
 			radiusFn = radius;
-
+	
 		//If we just set maxClusterRadius to a single number, we need to create
 		//a simple function to return that number. Otherwise, we just have to
 		//use the function we've passed in.
@@ -951,7 +951,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		this._maxZoom = maxZoom;
 		this._gridClusters = {};
 		this._gridUnclustered = {};
-
+	
 		//Set up DistanceGrids for each zoom
 		for (var zoom = maxZoom; zoom >= minZoom; zoom--) {
 			this._gridClusters[zoom] = new L.DistanceGrid(radiusFn(zoom));


### PR DESCRIPTION
The main use case for this is when you are dynamically filtering markers that are being added into the cluster layer using chunked loading. With large marker sets it is possible for the filter conditions to change mid importation.

Previously, calling the clearLayers function would only clear markers already added. If the addLayers function was currently importing markers these would be added after the clearLayers function was called resulting in an unexpected state.

This PR essentially keeps a track of the number of times the clearLayers function was called, and aborts an addLayers process if it began when the call count was less than the current call count of clearLayers.