### PR TITLE
Refactor(options): move clusterPane into options field

### DIFF
--- a/example/marker-clustering-pane.html
+++ b/example/marker-clustering-pane.html
@@ -51,19 +51,25 @@
 		var markersB = createMarkerClusterGroup('myclusterB', 'paneB');
 
 		function createMarkerClusterGroup(className, pane) {
-		    var mcg = L.markerClusterGroup({
-                maxClusterRadius: 120,
-                iconCreateFunction: function (cluster) {
-                    var markers = cluster.getAllChildMarkers();
-                    var n = 0;
-                    for (var i = 0; i < markers.length; i++) {
-                        n += markers[i].number;
-                    }
-                    return L.divIcon({ html: n, className: className, iconSize: L.point(40, 40) });
-                },
-                //Disable all of the defaults & specify the pane:
-                spiderfyOnMaxZoom: false, showCoverageOnHover: false, zoomToBoundsOnClick: false, clusterPane: pane
-            });
+			var options = {
+				maxClusterRadius: 120,
+				iconCreateFunction: function (cluster) {
+					var markers = cluster.getAllChildMarkers();
+					var n = 0;
+					for (var i = 0; i < markers.length; i++) {
+						n += markers[i].number;
+					}
+					return L.divIcon({ html: n, className: className, iconSize: L.point(40, 40) });
+				},
+				//Disable all of the defaults & specify the pane:
+				spiderfyOnMaxZoom: false,
+				showCoverageOnHover: false,
+				zoomToBoundsOnClick: false
+			};
+			if (pane) {
+				options.clusterPane = pane;
+			}
+		    var mcg = L.markerClusterGroup(options);
 		    return(mcg);
         }
 

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -7,6 +7,7 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 	options: {
 		maxClusterRadius: 80, //A cluster will cover at most this many pixels from its center
 		iconCreateFunction: null,
+		clusterPane: L.Marker.prototype.options.pane,
 
 		spiderfyOnMaxZoom: true,
 		showCoverageOnHover: true,
@@ -49,9 +50,6 @@ L.MarkerClusterGroup = L.FeatureGroup.extend({
 		if (!this.options.iconCreateFunction) {
 			this.options.iconCreateFunction = this._defaultIconCreateFunction;
 		}
-		if (!this.options.clusterPane) {
-		    this.options.clusterPane = L.Marker.prototype.options.pane;
-        }
 
 		this._featureGroup = L.featureGroup();
 		this._featureGroup.addEventParent(this);


### PR DESCRIPTION
Hi,

Follows PR https://github.com/Leaflet/Leaflet.markercluster/pull/819 which introduced `clusterPane` option.

This PR proposes to move the initialization of `clusterPane` from the `initialize` function into the dedicated `options` field, like most other options.
There is no real need to set it "manually" during initialization phase, instead of letting Leaflet class mechanism retrieve it automatically.

The case of `iconCreateFunction` option is different because it refers to a function that is defined in the same class. Therefore this function is not accessible until Leaflet finishes preparing the class.
But even that could be worked around, for example by moving that function to file context (it is actually like a static function, it is not related to an instance / it does not depend on `this`), so that we can refer to it from the `options` field.

By doing so, the `options` section would become slightly more easy to understand, but there would be a minor internal change: `_defaultIconCreateFunction` would no longer be modifiable, but I really doubt someone actually had to modify that default function (`iconCreateFunction` functionality would still be preserved).
Please let me know should you think that would be worth refactoring as well.