### PR TITLE
Fix(Spiderfier): min leg length for circle and skip 1st pos for spiral

### DIFF
--- a/src/MarkerCluster.Spiderfier.js
+++ b/src/MarkerCluster.Spiderfier.js
@@ -5,7 +5,7 @@ L.MarkerCluster.include({
 
 	_2PI: Math.PI * 2,
 	_circleFootSeparation: 25, //related to circumference of circle
-	_circleStartAngle: Math.PI / 6,
+	_circleStartAngle: 0,
 
 	_spiralFootSeparation:  28, //related to size of spiral (experiment!)
 	_spiralLengthStart: 11,
@@ -57,6 +57,8 @@ L.MarkerCluster.include({
 			res = [],
 			i, angle;
 
+		legLength = Math.max(legLength, 35); // Minimum distance to get outside the cluster icon.
+
 		res.length = count;
 
 		for (i = count - 1; i >= 0; i--) {
@@ -79,9 +81,13 @@ L.MarkerCluster.include({
 		res.length = count;
 
 		// Higher index, closer position to cluster center.
-		for (i = count - 1; i >= 0; i--) {
+		for (i = count; i >= 0; i--) {
+			// Skip the first position, so that we are already farther from center and we avoid
+			// being under the default cluster icon (especially important for Circle Markers).
+			if (i < count) {
+				res[i] = new L.Point(centerPt.x + legLength * Math.cos(angle), centerPt.y + legLength * Math.sin(angle))._round();
+			}
 			angle += separation / legLength + i * 0.0005;
-			res[i] = new L.Point(centerPt.x + legLength * Math.cos(angle), centerPt.y + legLength * Math.sin(angle))._round();
 			legLength += lengthFactor / angle;
 		}
 		return res;

--- a/src/MarkerCluster.Spiderfier.js
+++ b/src/MarkerCluster.Spiderfier.js
@@ -61,7 +61,7 @@ L.MarkerCluster.include({
 
 		res.length = count;
 
-		for (i = count - 1; i >= 0; i--) {
+		for (i = 0; i < count; i++) { // Clockwise, like spiral.
 			angle = this._circleStartAngle + i * angleStep;
 			res[i] = new L.Point(centerPt.x + legLength * Math.cos(angle), centerPt.y + legLength * Math.sin(angle))._round();
 		}


### PR DESCRIPTION
Hi,

This PR increases the minimum spiderfication leg length, so that markers (especially important for Circle Markers, which are displayed under DivIcons by default) are positioned outside the default Cluster icon in all situations.

**When the spiderfication is a circle (i.e. for < 9 child markers)**, this PR uses a minimum leg length of 35 pixels, in order to extend beyond the default cluster icon (size 40, hence radius 20px), including after the circle offset (10px).

2 children with fix: ![screenshot_20171125_124310](https://user-images.githubusercontent.com/12232803/33228925-37d960a4-d1de-11e7-9fa5-23da713aa665.png) ![screenshot_20171125_110050](https://user-images.githubusercontent.com/12232803/33228251-f7ed8500-d1cf-11e7-8ff8-5d4002c8cd68.png) w/o fix: ![screenshot_20171125_110143](https://user-images.githubusercontent.com/12232803/33228254-0b936f66-d1d0-11e7-84cc-27dbe5aa76aa.png) (left marker is not clickable)

3 children with fix: ![screenshot_20171125_124405](https://user-images.githubusercontent.com/12232803/33228937-56f71512-d1de-11e7-8252-a83c878e6156.png) ![screenshot_20171125_110259](https://user-images.githubusercontent.com/12232803/33228259-38f94642-d1d0-11e7-8f52-e214f9782e43.png) w/o fix: ![screenshot_20171125_110322](https://user-images.githubusercontent.com/12232803/33228261-438e873e-d1d0-11e7-84b3-283cf455f70e.png) (top marker is not clickable)

4 children with fix: ![screenshot_20171125_124450](https://user-images.githubusercontent.com/12232803/33228943-7208ea60-d1de-11e7-9cf6-0287fcee4a5b.png) ![screenshot_20171125_110456](https://user-images.githubusercontent.com/12232803/33228274-8527115c-d1d0-11e7-85aa-4bb6fcceaa27.png) w/o fix: ![screenshot_20171125_110537](https://user-images.githubusercontent.com/12232803/33228275-93ddb93a-d1d0-11e7-9e93-29d7f40e8c84.png) (top right marker is not clickable)

5 children with fix: ![screenshot_20171125_124554](https://user-images.githubusercontent.com/12232803/33228955-97aada08-d1de-11e7-92e1-21819ad8fc96.png) ![screenshot_20171125_111144](https://user-images.githubusercontent.com/12232803/33228312-70195ff8-d1d1-11e7-8c6c-ce413f223033.png) w/o fix: ![screenshot_20171125_111222](https://user-images.githubusercontent.com/12232803/33228313-86c6f6ca-d1d1-11e7-83f6-2e1b1f72d38c.png) (top marker is not clickable)

6 children with fix: ![screenshot_20171125_124705](https://user-images.githubusercontent.com/12232803/33228968-c2374b26-d1de-11e7-8a44-4df83c9d4f26.png) ![screenshot_20171125_111307](https://user-images.githubusercontent.com/12232803/33228317-aa273e4a-d1d1-11e7-8d12-3aec3e08e884.png) w/o fix: ![screenshot_20171125_111339](https://user-images.githubusercontent.com/12232803/33228319-b39b1e06-d1d1-11e7-8d8e-0a361c62124f.png)

**When the spiderfication is a spiral (i.e. for >= 9 child markers)**, it simply skips the first position, the one that is always under the icon. By not touching the rest of the spiral computation, the general shape of the spiral is preserved (approximately).

9 children with fix: ![screenshot_20171125_124819](https://user-images.githubusercontent.com/12232803/33228971-f129620c-d1de-11e7-8ca0-fa5c89ed322a.png) ![screenshot_20171125_123753](https://user-images.githubusercontent.com/12232803/33228860-805f9f24-d1dd-11e7-9671-26ff2d6dbdc0.png) w/o fix: ![screenshot_20171125_123837](https://user-images.githubusercontent.com/12232803/33228868-92acf726-d1dd-11e7-841b-84e7536e0eaa.png)

10 children with fix: ![screenshot_20171125_124923](https://user-images.githubusercontent.com/12232803/33228977-148dd2f0-d1df-11e7-9430-b5c45b05f576.png) ![screenshot_20171125_123939](https://user-images.githubusercontent.com/12232803/33228882-bc305606-d1dd-11e7-85fa-fc53dc555c24.png) w/o fix: ![screenshot_20171125_124008](https://user-images.githubusercontent.com/12232803/33228886-c805f71a-d1dd-11e7-98e6-6d831bf45e50.png)

15 children with fix: ![screenshot_20171125_125026](https://user-images.githubusercontent.com/12232803/33228984-3ac4145c-d1df-11e7-8786-1d8add0899b2.png) ![screenshot_20171125_124101](https://user-images.githubusercontent.com/12232803/33228896-ebbb0592-d1dd-11e7-99e9-2e57b520833e.png) w/o fix: ![screenshot_20171125_124129](https://user-images.githubusercontent.com/12232803/33228900-f8cc51b4-d1dd-11e7-8662-980999681f97.png)








Demo with fix: https://jsfiddle.net/aue7uhe2/27/
Without fix: https://jsfiddle.net/aue7uhe2/28/

Fix https://github.com/Leaflet/Leaflet.markercluster/issues/431