### PR TITLE
Store different opacity when unclustered

### DIFF
--- a/src/MarkerOpacity.js
+++ b/src/MarkerOpacity.js
@@ -11,12 +11,12 @@
 L.Marker.include({
 	
 	clusterHide: function () {
-		this.options.opacityWhenUnclustered = this.options.opacity || 1;
+		this.options.opacityWhenUnclustered = Number.isFinite(this.options.opacity) ? this.options.opacity : 1;
 		return this.setOpacity(0);
 	},
 	
 	clusterShow: function () {
-		var ret = this.setOpacity(this.options.opacity || this.options.opacityWhenUnclustered);
+		var ret = this.setOpacity(Number.isFinite(this.options.opacity) ? this.options.opacity : this.options.opacityWhenUnclustered);
 		delete this.options.opacityWhenUnclustered;
 		return ret;
 	}


### PR DESCRIPTION
Following code store opacity number 1 if this.options.opacity equals 0, but the number 0 should be stored.

`this.options.opacityWhenUnclustered = this.options.opacity || 1;`

Therefore, need to check if it's number or not before stored.