### PR TITLE
Fix(zoomAnim): add compatibility with non-icon-based Markers

### DIFF
--- a/spec/suites/zoomAnimationSpec.js
+++ b/spec/suites/zoomAnimationSpec.js
@@ -378,5 +378,40 @@
 			expect(marker3._icon).to.not.be(null);
 			sinon.assert.calledOnce(zoomCallbackSpy);
 		});
+
+		it('zoom and executes callback even for non-icon-based Marker', function () {
+			group = new L.MarkerClusterGroup();
+
+			var marker1 = new L.CircleMarker([59.9520, 30.3307]);
+			var marker2 = new L.CircleMarker([59.9516, 30.3308]);
+			var marker3 = new L.CircleMarker([59.9513, 30.3312]);
+
+			group.addLayer(marker1);
+			group.addLayer(marker2);
+			group.addLayer(marker3);
+			map.addLayer(group);
+
+			var zoomCallbackSpy = sinon.spy();
+
+			//Markers will be visible on zoom 18
+			map.setView([59.9520, 30.3307], 16);
+
+			clock.tick(1000);
+
+			expect(map.hasLayer(marker1)).to.be(false);
+			expect(map.hasLayer(marker2)).to.be(false);
+			expect(map.hasLayer(marker3)).to.be(false);
+
+			group.zoomToShowLayer(marker1, zoomCallbackSpy);
+
+			//Run the the animation
+			clock.tick(1000);
+
+			//Now the markers should all be visible (zoomed or spiderfied), and callback called once
+			expect(map.hasLayer(marker1)).to.be(true);
+			expect(map.hasLayer(marker2)).to.be(true);
+			expect(map.hasLayer(marker3)).to.be(true);
+			sinon.assert.calledOnce(zoomCallbackSpy);
+		});
 	});
 });

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -541,16 +541,20 @@ export var MarkerClusterGroup = L.MarkerClusterGroup = L.FeatureGroup.extend({
 	//Zoom down to show the given layer (spiderfying if necessary) then calls the callback
 	zoomToShowLayer: function (layer, callback) {
 
+		var map = this._map;
+
 		if (typeof callback !== 'function') {
 			callback = function () {};
 		}
 
 		var showMarker = function () {
-			if ((layer._icon || layer.__parent._icon) && !this._inZoomAnimation) {
+			// Assumes that map.hasLayer checks for direct appearance on map, not recursively calling
+			// hasLayer on Layer Groups that are on map (typically not calling this MarkerClusterGroup.hasLayer, which would always return true)
+			if ((map.hasLayer(layer) || map.hasLayer(layer.__parent)) && !this._inZoomAnimation) {
 				this._map.off('moveend', showMarker, this);
 				this.off('animationend', showMarker, this);
 
-				if (layer._icon) {
+				if (map.hasLayer(layer)) {
 					callback();
 				} else if (layer.__parent._icon) {
 					this.once('spiderfied', callback, this);


### PR DESCRIPTION
Hi,

Fix https://github.com/Leaflet/Leaflet.markercluster/issues/904

As explained in the above issue, [`zoomToShowLayer`](https://github.com/Leaflet/Leaflet.markercluster#other-group-methods) method currently does not work well when clustered Markers do not use Icons (typically Circle Markers).

I will push the PR in 2 steps:
1. Only with the added test to show that it fails in current state.
2. With fix to show that now it passes.

With this fix, it should also be in a better position to handle non-icon-based Cluster Markers as well, although I suspect there might be other places that also need a fix to provide full compatibility.