### PR TITLE
Fix(addLayers): unspiderfy before adding new Marker(s)

### DIFF
--- a/spec/suites/AddLayer.MultipleSpec.js
+++ b/spec/suites/AddLayer.MultipleSpec.js
@@ -122,4 +122,39 @@
 
 		expect(map._panes.markerPane.childNodes.length).to.be(2);
 	});
+
+	it('unspiderfies before adding a new Marker', function () {
+
+		group = new L.MarkerClusterGroup();
+
+		var marker = new L.Marker([1.5, 1.5]);
+		var marker2 = new L.Marker([1.5, 1.5]);
+		var marker3 = new L.Marker([1.5, 1.5]);
+
+		group.addLayers([marker, marker2]);
+		map.addLayer(group);
+
+		expect(marker._icon).to.be(undefined);
+		expect(marker2._icon).to.be(undefined);
+
+		group.zoomToShowLayer(marker);
+		//Run the the animation
+		clock.tick(1000);
+
+		expect(marker._icon).to.not.be(undefined);
+		expect(marker._icon).to.not.be(null);
+		expect(marker2._icon).to.not.be(undefined);
+		expect(marker2._icon).to.not.be(null);
+
+		group.addLayer(marker3);
+		//Run the the animation
+		clock.tick(1000);
+
+		expect(marker._icon).to.be(null);
+		expect(marker2._icon).to.be(null);
+		expect(marker3._icon).to.be(undefined);
+		expect(marker3.__parent._icon).to.not.be(undefined);
+		expect(marker3.__parent._icon).to.not.be(null);
+		expect(marker3.__parent._icon.innerText.trim()).to.equal('3');
+	});
 });

--- a/spec/suites/AddLayersSpec.js
+++ b/spec/suites/AddLayersSpec.js
@@ -120,4 +120,44 @@
 
 		expect(map._panes.markerPane.childNodes.length).to.be(2);
 	});
+
+	it('unspiderfies before adding new Marker(s)', function () {
+
+		var clock = sinon.useFakeTimers();
+
+		group = new L.MarkerClusterGroup();
+
+		var marker = new L.Marker([1.5, 1.5]);
+		var marker2 = new L.Marker([1.5, 1.5]);
+		var marker3 = new L.Marker([1.5, 1.5]);
+
+		group.addLayers([marker, marker2]);
+		map.addLayer(group);
+
+		expect(marker._icon).to.be(undefined);
+		expect(marker2._icon).to.be(undefined);
+
+		group.zoomToShowLayer(marker);
+		//Run the the animation
+		clock.tick(1000);
+
+		expect(marker._icon).to.not.be(undefined);
+		expect(marker._icon).to.not.be(null);
+		expect(marker2._icon).to.not.be(undefined);
+		expect(marker2._icon).to.not.be(null);
+
+		group.addLayers([marker3]);
+		//Run the the animation
+		clock.tick(1000);
+
+		expect(marker._icon).to.be(null);
+		expect(marker2._icon).to.be(null);
+		expect(marker3._icon).to.be(undefined);
+		expect(marker3.__parent._icon).to.not.be(undefined);
+		expect(marker3.__parent._icon).to.not.be(null);
+		expect(marker3.__parent._icon.innerText.trim()).to.equal('3');
+
+		clock.restore();
+		clock = null;
+	});
 });

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -209,6 +209,12 @@ export var MarkerClusterGroup = L.MarkerClusterGroup = L.FeatureGroup.extend({
 			var started = (new Date()).getTime();
 			var process = L.bind(function () {
 				var start = (new Date()).getTime();
+
+				// Make sure to unspiderfy before starting to add some layers
+				if (this._map && this._unspiderfy) {
+          this._unspiderfy();
+        }
+
 				for (; offset < l; offset++) {
 					if (chunked && offset % 200 === 0) {
 						// every couple hundred markers, instrument the time elapsed since processing started:

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -212,8 +212,8 @@ export var MarkerClusterGroup = L.MarkerClusterGroup = L.FeatureGroup.extend({
 
 				// Make sure to unspiderfy before starting to add some layers
 				if (this._map && this._unspiderfy) {
-          this._unspiderfy();
-        }
+					this._unspiderfy();
+				}
 
 				for (; offset < l; offset++) {
 					if (chunked && offset % 200 === 0) {


### PR DESCRIPTION
Hi again,

Fix https://github.com/Leaflet/Leaflet.markercluster/issues/879

Add the call to `_unsiperfy` within the `process` subtask of `addLayers`, so that it works even if for some reason a cluster has been spiderfied while `addLayers` is in the middle of processing.

As previously, I will push this PR in 2 steps (test, then fix).