### PR TITLE
Expose essential CSS in package.json style attr (fixes #906)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"leaflet": "~1.3.1"
 	},
 	"main": "dist/leaflet.markercluster-src.js",
+	"style": "dist/MarkerCluster.css",
 	"scripts": {
 		"test": "karma start ./spec/karma.conf.js",
 		"prepublish": "jake",


### PR DESCRIPTION
The `style` attribute is useful when using `Leaflet.markerCluster` with most node bundling systems (e.g. Browserify, Webpack) or any setup that uses PostCSS.

Note - only one of the two CSS files is exposed with this change. The `package.json` `style` attribute doesn't have a standardised behaviour but in the most popular implementations accepts only a string (as opposed to an array of strings). There are two css files shipped with `Leaflet.markerCluster`, but only [`MarkerCluster.css`](https://github.com/Leaflet/Leaflet.markercluster/blob/master/dist/MarkerCluster.css) is essential (`MarkerCluster.Default.css` is only needed for some use-cases).