### PR TITLE
Making the package compatible with leaflet 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"uglify-js": "3.4.9"
 	},
 	"peerDependencies": {
-		"leaflet": "~1.3.1"
+		"leaflet": "^1.3"
 	},
 	"main": "dist/leaflet.markercluster-src.js",
 	"style": "dist/MarkerCluster.css",


### PR DESCRIPTION
Installing marker cluster through npm you get always the following information message:

_leaflet.markercluster@1.4.1 requires a peer of leaflet@~1.3.1 but none is installed. You must install peer dependencies yourself._

So making the dependency less strict and available for all leaflet 1.x versions would be good as it actually works up to leaflet 1.6.

Solves #938.