### PR TITLE
Improve performance of addLayers by preallocating array

### DIFF
--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -291,7 +291,8 @@ export var MarkerClusterGroup = L.MarkerClusterGroup = L.FeatureGroup.extend({
 
 			process();
 		} else {
-			var needsClustering = this._needsClustering;
+			var needsClustering = new Array(l - offset);	// improve performance by preallocating the maximum size of our array
+			var tail = 0;
 
 			for (; offset < l; offset++) {
 				m = layersArray[offset];
@@ -317,8 +318,11 @@ export var MarkerClusterGroup = L.MarkerClusterGroup = L.FeatureGroup.extend({
 					continue;
 				}
 
-				needsClustering.push(m);
+				needsClustering[tail++] = m;
 			}
+
+			needsClustering = needsClustering.slice(0, tail);	// truncate empty elements
+			this._needsClustering.push.apply(this._needsClustering, needsClustering);
 		}
 		return this;
 	},


### PR DESCRIPTION
Presently, `addLayers` pushes a new element onto `MarkerClusterGroup._needsClustering` for each qualifying element in `layersArray`. This is inefficient because the array is being resized upon every iteration, which is a very expensive operation. This problem really starts to become evident when adding a large number of markers.

This pull request resolves this problem by preallocating the array instead of repeatedly resizing it. Using a dataset of 120,866 markers, this simple fix reduced my average `addLayers` call time from 8.9s to 0.5s.