### PR TITLE
Check for finite min and max zoom properties

### DIFF
--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -957,6 +957,13 @@ export var MarkerClusterGroup = L.MarkerClusterGroup = L.FeatureGroup.extend({
 		this._gridUnclustered = {};
 
 		//Set up DistanceGrids for each zoom
+				
+		if (!isFinite(maxZoom) ) {
+          		throw "Map has no maxZoom specified";
+        	}
+        	if (!isFinite(minZoom)) {
+            		throw "Map has no minZoom specified";
+        	}
 		for (var zoom = maxZoom; zoom >= minZoom; zoom--) {
 			this._gridClusters[zoom] = new L.DistanceGrid(radiusFn(zoom));
 			this._gridUnclustered[zoom] = new L.DistanceGrid(radiusFn(zoom));


### PR DESCRIPTION
In the event leaflet sends "infinity" as a max or min zoom while generating the initial clusters, the loop to set up the grid clusters will crash the browser. Issue # 894