### PR TITLE
Update package.json with leaflet 1.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"karma-phantomjs-launcher": "^1.0.4",
 		"karma-rollup-preprocessor": "7.0.0",
 		"karma-safari-launcher": "^1.0.0",
-		"leaflet": "^1.3.1",
+		"leaflet": "^1.7.1",
 		"mocha": "6.0.2",
 		"phantomjs-prebuilt": "^2.1.14",
 		"rollup": "1.3.2",
@@ -25,7 +25,7 @@
 		"uglify-js": "3.4.9"
 	},
 	"peerDependencies": {
-		"leaflet": "~1.3.1"
+		"leaflet": "~1.7.1"
 	},
 	"main": "dist/leaflet.markercluster-src.js",
 	"style": "dist/MarkerCluster.css",


### PR DESCRIPTION
Error installing project if you are using leaflet 1.7.1:

npm WARN Found: leaflet@1.7.1
npm WARN node_modules/leaflet
npm WARN   leaflet@"^1.7.1" from the root project
npm WARN
npm WARN Could not resolve dependency:
npm WARN peer leaflet@"~1.3.1" from leaflet.markercluster@1.4.1
npm WARN node_modules/leaflet.markercluster
npm WARN   leaflet.markercluster@"^1.4.1" from the root project