### PR TITLE
spiderfyShapePositions now receives the full list of childMarkers

### DIFF
--- a/src/MarkerCluster.Spiderfier.js
+++ b/src/MarkerCluster.Spiderfier.js
@@ -31,7 +31,7 @@ L.MarkerCluster.include({
 		//TODO Maybe: childMarkers order by distance to center
 
 		if (this._group.options.spiderfyShapePositions) {
-			positions = this._group.options.spiderfyShapePositions(childMarkers.length, center);
+			positions = this._group.options.spiderfyShapePositions(childMarkers.length, center, childMarkers);
 		} else if (childMarkers.length >= this._circleSpiralSwitchover) {
 			positions = this._generatePointsSpiral(childMarkers.length, center);
 		} else {


### PR DESCRIPTION
Done as a third argument to prevent changing the method signature.

One example use case for this is creating a spiderfy in which all markers spider to their original positions, rather than in a circle or spiral.