### PR TITLE
Adding "markers" for clusters in aria-label for accessibility

### DIFF
--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -830,7 +830,7 @@ export var MarkerClusterGroup = L.MarkerClusterGroup = L.FeatureGroup.extend({
 			c += 'large';
 		}
 
-		return new L.DivIcon({ html: '<div><span>' + childCount + '</span></div>', className: 'marker-cluster' + c, iconSize: new L.Point(40, 40) });
+		return new L.DivIcon({ html: '<div><span>' + childCount + ' <span aria-label="markers"></span>' + '</span></div>', className: 'marker-cluster' + c, iconSize: new L.Point(40, 40) });
 	},
 
 	_bindEvents: function () {


### PR DESCRIPTION
This is adding invisible "markers" information with aria-label for each marker cluster to fix https://github.com/Leaflet/Leaflet.markercluster/issues/1006 and each marker cluster now reads better "N markers" not just "N".