### PR TITLE
Cancel zoomOrSpiderfy if default prevented

### DIFF
--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -857,7 +857,7 @@ export var MarkerClusterGroup = L.MarkerClusterGroup = L.FeatureGroup.extend({
 		var cluster = e.layer,
 		    bottomCluster = cluster;
 
-		if (e.type === 'clusterkeypress' && e.originalEvent && e.originalEvent.keyCode !== 13) {
+		if (e.type === 'clusterkeypress' && e.originalEvent && e.originalEvent.keyCode !== 13 || e.originalEvent.defaultPrevented) {
 			return;
 		}
 


### PR DESCRIPTION
Related to #1101
If default has been prevented on the event coming to ```L.MarkerClusterGroup``` cancel further execution in ```_zoomOrSpiderfy```. This allows for custom logic on whether a cluster is allowed to be zoomed-in / spiderfyed or not.