### PR TITLE
Fix markers disappearing when a move interrupts a cluster zoom animation

### DIFF
--- a/spec/suites/zoomAnimationInterruptSpec.js
+++ b/spec/suites/zoomAnimationInterruptSpec.js
@@ -1,0 +1,73 @@
+describe('zoomAnimation move interrupt', function () {
+	/////////////////////////////
+	// SETUP FOR EACH TEST
+	/////////////////////////////
+	var div, map, group, clock;
+
+	beforeEach(function () {
+		clock = sinon.useFakeTimers();
+
+		div = document.createElement('div');
+		div.style.width = '200px';
+		div.style.height = '200px';
+		document.body.appendChild(div);
+
+		map = L.map(div, { maxZoom: 18, trackResize: false });
+		map.setView([0, 0], 16);
+	});
+
+	afterEach(function () {
+		if (group instanceof L.MarkerClusterGroup) {
+			group.clearLayers();
+			map.removeLayer(group);
+		}
+
+		map.remove();
+		document.body.removeChild(div);
+		clock.restore();
+
+		div = map = group = clock = null;
+	});
+
+	/////////////////////////////
+	// TESTS
+	/////////////////////////////
+
+	// Regression test for markers disappearing when a map move lands while a cluster
+	// zoom animation is still pending. An animated cluster zoom finalises from a deferred
+	// _enqueue callback, so until it runs `_inZoomAnimation` is > 0. A moveend arriving in
+	// that window used to bail out of `_moveEnd` (`if (this._inZoomAnimation) return;`) and
+	// was never retried, so markers that should appear in the newly revealed bounds were
+	// dropped and stayed missing until the next interaction. See #140, #886, #512, #1056.
+	it('does not drop a move that arrives during a pending cluster zoom animation', function () {
+		group = new L.MarkerClusterGroup();
+		group.addLayer(new L.Marker([0, 0]));
+		group.addLayer(new L.Marker([0.5, 0.5]));
+		map.addLayer(group);
+
+		// Let initial clustering settle.
+		clock.tick(1000);
+
+		// Reproduce the state of an in-flight cluster zoom whose finalisation is still
+		// queued: `_inZoomAnimation` is raised and the matching finaliser sits on the
+		// deferred queue (the real animated zoom does this via _animationStart/_enqueue).
+		// Setting it directly keeps the test independent of CSS-transition support.
+		group._inZoomAnimation++;
+		group._enqueue(function () {
+			group._inZoomAnimation--;
+		});
+		expect(group._inZoomAnimation).to.be.above(0);
+		expect(group._queue.length).to.be(1);
+
+		// A move (same zoom, so only moveend fires — not zoomend) arrives while that
+		// animation is still pending. Without the fix `_moveEnd` returns immediately and
+		// the move is dropped, leaving the animation unfinalised; with the fix `_moveEnd`
+		// flushes the queue first and then processes the move against a settled state.
+		map.panTo([0.5, 0.5], { animate: false });
+
+		// The move was handled instead of dropped: the pending animation was finalised
+		// (counter back to 0, deferred queue drained) rather than left hanging.
+		expect(group._inZoomAnimation).to.be(0);
+		expect(group._queue.length).to.be(0);
+	});
+});

--- a/src/MarkerClusterGroup.js
+++ b/src/MarkerClusterGroup.js
@@ -726,7 +726,7 @@ export var MarkerClusterGroup = L.MarkerClusterGroup = L.FeatureGroup.extend({
 		delete e.target.__dragStart;
 		if (dragStart) {
 			this._moveChild(e.target, dragStart, e.target._latlng);
-		}		
+		}
 	},
 
 
@@ -935,7 +935,18 @@ export var MarkerClusterGroup = L.MarkerClusterGroup = L.FeatureGroup.extend({
 
 	_moveEnd: function () {
 		if (this._inZoomAnimation) {
-			return;
+			// A move landed while a cluster zoom animation is still pending (its cleanup is
+			// deferred on the _enqueue timer). Finalise that animation synchronously by
+			// flushing its queue instead of dropping this move: otherwise the markers that
+			// should appear in the newly revealed bounds are never added and vanish until
+			// the next interaction (e.g. markers disappearing after a resize-triggered fit).
+			this._processQueue();
+
+			// If the flush did not settle the animation (should not happen), keep the
+			// original guard so we never reconcile against a half-animated tree.
+			if (this._inZoomAnimation) {
+				return;
+			}
 		}
 
 		var newBounds = this._getExpandedVisibleBounds();
@@ -968,7 +979,7 @@ export var MarkerClusterGroup = L.MarkerClusterGroup = L.FeatureGroup.extend({
 		this._gridUnclustered = {};
 
 		//Set up DistanceGrids for each zoom
-				
+
 		if (!isFinite(maxZoom) ) {
           		throw "Map has no maxZoom specified";
         	}


### PR DESCRIPTION
_moveEnd bailed out while a cluster zoom animation was still pending (_inZoomAnimation > 0) and was never retried. A moveend landing in that window — e.g. a fitBounds/setView triggered by a resize while a zoom is mid-flight — was silently dropped, so markers in the newly revealed bounds were never added and stayed missing until the next interaction.

Instead of dropping the move, finalise the pending animation synchronously by flushing its queue (_processQueue runs the deferred cleanup and clears _inZoomAnimation), then fall through and process the move against a settled state.

Adds a regression spec that drives a move during a pending cluster zoom animation and asserts the queued animation is finalised (the move handled) rather than dropped.

Refs #140, #886